### PR TITLE
fix: make version tool work outside project directory

### DIFF
--- a/tests/tools/version.test.ts
+++ b/tests/tools/version.test.ts
@@ -46,38 +46,30 @@ describe('Version Tool', () => {
       const versionInfo = getVersionInfo();
 
       expect(versionInfo).toHaveProperty('version');
-      expect(versionInfo).toHaveProperty('buildTime');
       expect(versionInfo).toHaveProperty('nodeVersion');
       expect(versionInfo).toHaveProperty('platform');
       expect(versionInfo).toHaveProperty('arch');
 
       expect(typeof versionInfo.version).toBe('string');
-      expect(typeof versionInfo.buildTime).toBe('string');
       expect(typeof versionInfo.nodeVersion).toBe('string');
       expect(typeof versionInfo.platform).toBe('string');
       expect(typeof versionInfo.arch).toBe('string');
     });
 
-    it('should include git information when available', () => {
+    it('should return valid version string', () => {
       const versionInfo = getVersionInfo();
 
-      // Git info may or may not be available depending on environment
-      if (versionInfo.gitCommit) {
-        expect(typeof versionInfo.gitCommit).toBe('string');
-        expect(versionInfo.gitCommit.length).toBeGreaterThan(0);
-      }
-
-      if (versionInfo.gitBranch) {
-        expect(typeof versionInfo.gitBranch).toBe('string');
-        expect(versionInfo.gitBranch.length).toBeGreaterThan(0);
-      }
+      expect(versionInfo.version).toBeDefined();
+      expect(versionInfo.version.length).toBeGreaterThan(0);
+      expect(typeof versionInfo.version).toBe('string');
     });
 
-    it('should return valid ISO timestamp for buildTime', () => {
+    it('should return valid runtime information', () => {
       const versionInfo = getVersionInfo();
       
-      expect(() => new Date(versionInfo.buildTime)).not.toThrow();
-      expect(new Date(versionInfo.buildTime).toISOString()).toBe(versionInfo.buildTime);
+      expect(versionInfo.nodeVersion).toMatch(/^v\d+\.\d+\.\d+/);
+      expect(['darwin', 'linux', 'win32']).toContain(versionInfo.platform);
+      expect(['arm64', 'x64', 'x86']).toContain(versionInfo.arch);
     });
   });
 
@@ -91,7 +83,6 @@ describe('Version Tool', () => {
       expect(result).toHaveProperty('timestamp');
 
       expect(result.versionInfo).toHaveProperty('version');
-      expect(result.versionInfo).toHaveProperty('buildTime');
       expect(result.versionInfo).toHaveProperty('nodeVersion');
       expect(result.versionInfo).toHaveProperty('platform');
       expect(result.versionInfo).toHaveProperty('arch');


### PR DESCRIPTION
## Summary
- Fixed version tool to work reliably when MCP server is used outside the project directory
- Removed dependencies on current working directory and git repository
- Simplified version info to return only reliable data

## Changes Made
- Find package.json relative to module installation path instead of current working directory
- Remove git dependencies (git commands) that could fail in other environments  
- Remove misleading buildTime field that wasn't actual build time
- Update VersionInfo interface to only include reliable fields
- Update tests to match new simplified version format

## Test Plan
- [x] All 485 tests pass
- [x] Version tool works when called from project directory
- [x] Version tool will work when MCP server is installed and used elsewhere
- [x] No regressions in existing functionality

## Impact
This ensures the MCP version tool works reliably in any environment where the MCP server is deployed, not just in the development directory.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified version information to only include the app version, Node.js version, platform, and architecture. Git commit, branch, and build time details are no longer provided.

* **Tests**
  * Updated tests to remove checks for git-related and build time properties, focusing instead on the available version and runtime environment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->