### PR TITLE
docs: clarify single label guideline in release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@
 #
 # Configures automatic release notes generation when creating GitHub Releases.
 # GitHub will categorize merged PRs based on labels and generate formatted changelog.
+# Each PR should have exactly one primary label to appear in a single category.
 #
 # See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 


### PR DESCRIPTION
## Description

This PR adds a clarifying comment to .github/release.yml explaining that each PR should have exactly one primary label to appear in a single category in release notes.

## Related Issues

Testing the automatic release notes categorization feature implemented in previous commit.

## Type of Change

- [x] 📚 Documentation changes

## Testing

- [x] Comment added to release.yml
- [x] Will verify release notes generation after merge

## Checklist

- [x] Documentation updated
- [x] PR title follows Conventional Commits format