### PR TITLE
feat(mcp-client): support authentication for outbound MCP server connections

### DIFF
--- a/changelog.d/414-mcp-client-auth.feature.md
+++ b/changelog.d/414-mcp-client-auth.feature.md
@@ -1,9 +1,10 @@
 ### MCP Client Outbound Authentication
 
-MCP server connections now support authentication via two mechanisms:
+MCP server connections now support authentication via three mechanisms:
 
 - **Static token (`authProvider`)**: Bearer tokens from K8s Secrets, passed to the MCP SDK's native `authProvider` interface. Use for MCP-spec-compliant servers requiring JWT or API key auth.
 - **Custom headers (`requestInit.headers`)**: JSON-encoded HTTP headers from K8s Secrets, passed via `requestInit`. Use for non-spec servers requiring custom auth headers.
+- **OAuth client_credentials (`authProvider`)**: OAuth 2.0 client_credentials grant for server-to-server auth. Uses the MCP SDK's `OAuthClientProvider` interface with RFC 9728 discovery. Client ID configured in Helm values; client secret stored in K8s Secrets. Supports optional scope configuration.
 
 Authentication is configured per MCP server in the Helm chart's `mcpServers` values. Credentials are always stored in K8s Secrets and injected as environment variables — never in ConfigMaps or Helm values.
 

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -176,6 +176,13 @@ Auth credentials are injected as env vars from K8s Secrets (not stored in Config
 {{- if $config.auth.headers -}}
 {{- $_ := set $auth "headersEnvVar" (printf "MCP_HEADERS_%s" $upperName) -}}
 {{- end -}}
+{{- if $config.auth.oauth -}}
+{{- $oauth := dict "clientId" $config.auth.oauth.clientId "clientSecretEnvVar" (printf "MCP_OAUTH_SECRET_%s" $upperName) -}}
+{{- if $config.auth.oauth.scope -}}
+{{- $_ := set $oauth "scope" $config.auth.oauth.scope -}}
+{{- end -}}
+{{- $_ := set $auth "oauth" $oauth -}}
+{{- end -}}
 {{- if $auth -}}
 {{- $server = merge $server (dict "auth" $auth) -}}
 {{- end -}}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -206,6 +206,13 @@ spec:
               name: {{ $config.auth.headers.existingSecret.name }}
               key: {{ $config.auth.headers.existingSecret.key }}
 {{- end }}
+{{- if and $config.auth.oauth $config.auth.oauth.existingSecret }}
+        - name: MCP_OAUTH_SECRET_{{ $upperName }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $config.auth.oauth.existingSecret.name }}
+              key: {{ $config.auth.oauth.existingSecret.key }}
+{{- end }}
 {{- end }}
 {{- end }}
         lifecycle:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -387,9 +387,10 @@ plugins:
 #
 # Authentication (PRD #414):
 # MCP servers requiring auth use `auth` config with credentials stored in K8s Secrets.
-# Two auth modes:
+# Three auth modes:
 #   - auth.token: Static bearer token via authProvider (MCP-spec-compliant)
 #   - auth.headers: Custom HTTP headers via requestInit (non-spec fallback)
+#   - auth.oauth: OAuth client_credentials via OAuthClientProvider (MCP Authorization spec)
 # Credentials are injected as env vars from Secrets — never stored in ConfigMaps.
 mcpServers: {}
   # Example: Prometheus MCP server (no auth — in-cluster trust)
@@ -424,6 +425,23 @@ mcpServers: {}
   #       existingSecret:
   #         name: legacy-auth            # K8s Secret name
   #         key: auth-headers            # Key containing JSON: {"X-API-Key":"abc123"}
+  #
+  # Example: OAuth-authenticated MCP server (PRD #414, MCP Authorization spec)
+  # Uses client_credentials grant for server-to-server auth.
+  # The MCP SDK discovers the auth server via RFC 9728 metadata from the endpoint.
+  # upstream-dot-ai:
+  #   enabled: true
+  #   endpoint: "https://dot-ai.example.com/mcp"
+  #   attachTo:
+  #     - query
+  #     - remediate
+  #   auth:
+  #     oauth:
+  #       clientId: "dot-ai-downstream"    # OAuth client ID
+  #       scope: "mcp:tools"               # Optional OAuth scope
+  #       existingSecret:
+  #         name: upstream-oauth-creds     # K8s Secret name
+  #         key: client-secret             # Key containing the OAuth client secret
   #
   # Example: Jaeger MCP server for tracing (no auth)
   # jaeger:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vfarcic/dot-ai",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vfarcic/dot-ai",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/alibaba": "^1.0.10",
@@ -1154,7 +1154,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2694,7 +2693,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2808,7 +2806,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3122,7 +3119,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -3172,7 +3168,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3226,7 +3221,6 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
       "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.66",
         "@ai-sdk/provider": "3.0.8",
@@ -3761,7 +3755,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4156,7 +4149,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4549,7 +4541,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4820,7 +4811,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5262,7 +5252,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5463,7 +5452,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -6653,7 +6641,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7602,7 +7589,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7758,7 +7744,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7857,7 +7842,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -8023,7 +8007,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8054,7 +8037,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8120,7 +8102,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/core/mcp-client-manager.ts
+++ b/src/core/mcp-client-manager.ts
@@ -14,7 +14,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
-import type { OAuthTokens, OAuthClientMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { OAuthTokens, OAuthClientMetadata, OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
 import {
   McpServerConfig,
   McpServerAuthConfig,
@@ -77,12 +77,98 @@ export class StaticTokenAuthProvider implements OAuthClientProvider {
 }
 
 /**
+ * OAuthClientProvider using client_credentials grant for server-to-server auth.
+ *
+ * When the MCP SDK detects a 401 from the target server, it uses this provider
+ * to perform OAuth 2.1 discovery (RFC 9728) and obtain tokens via the
+ * client_credentials grant. Tokens are cached in memory and refreshed
+ * automatically by the SDK when they expire.
+ *
+ * PRD #414: MCP Client Outbound Authentication (M4)
+ */
+export class ClientCredentialsAuthProvider implements OAuthClientProvider {
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly scope?: string;
+  private cachedTokens?: OAuthTokens;
+  private cachedClientInfo?: OAuthClientInformationFull;
+  private cachedCodeVerifier = '';
+
+  constructor(config: { clientId: string; clientSecret: string; scope?: string }) {
+    this.clientId = config.clientId;
+    this.clientSecret = config.clientSecret;
+    this.scope = config.scope;
+  }
+
+  get redirectUrl(): undefined { return undefined; }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      redirect_uris: [],
+      client_name: 'dot-ai',
+      grant_types: ['client_credentials'],
+      token_endpoint_auth_method: 'client_secret_post',
+    };
+  }
+
+  clientInformation(): OAuthClientInformationFull | undefined {
+    if (this.cachedClientInfo) return this.cachedClientInfo;
+    // Return pre-registered client info so the SDK skips dynamic registration
+    return {
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+      client_id_issued_at: 0,
+      redirect_uris: [],
+      client_name: 'dot-ai',
+      grant_types: ['client_credentials'],
+      token_endpoint_auth_method: 'client_secret_post',
+    } as OAuthClientInformationFull;
+  }
+
+  async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
+    this.cachedClientInfo = info;
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    return this.cachedTokens;
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    this.cachedTokens = tokens;
+  }
+
+  async redirectToAuthorization(): Promise<void> {
+    // client_credentials is non-interactive — no browser redirect needed
+  }
+
+  async saveCodeVerifier(verifier: string): Promise<void> {
+    this.cachedCodeVerifier = verifier;
+  }
+
+  async codeVerifier(): Promise<string> {
+    return this.cachedCodeVerifier;
+  }
+
+  /**
+   * Prepare a client_credentials token request.
+   * The SDK calls this to determine which grant type to use.
+   */
+  prepareTokenRequest(scope?: string): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('grant_type', 'client_credentials');
+    const effectiveScope = scope ?? this.scope;
+    if (effectiveScope) params.set('scope', effectiveScope);
+    return params;
+  }
+}
+
+/**
  * Resolve transport options (authProvider and/or requestInit) from auth config.
  *
  * Reads token/header values from environment variables (sourced from K8s Secrets).
  * Returns partial options to merge into StreamableHTTPClientTransportOptions.
  *
- * PRD #414: MCP Client Outbound Authentication (M1 + M2)
+ * PRD #414: MCP Client Outbound Authentication (M1 + M2 + M4)
  */
 export function resolveTransportAuth(
   auth: McpServerAuthConfig | undefined,
@@ -136,6 +222,30 @@ export function resolveTransportAuth(
       logger.warn('MCP server auth headersEnvVar configured but env var is empty', {
         server: serverName,
         envVar: auth.headersEnvVar,
+      });
+    }
+  }
+
+  // M4: OAuth client_credentials → authProvider (takes precedence over tokenEnvVar)
+  if (auth.oauth) {
+    const clientSecret = process.env[auth.oauth.clientSecretEnvVar];
+    if (clientSecret) {
+      result.authProvider = new ClientCredentialsAuthProvider({
+        clientId: auth.oauth.clientId,
+        clientSecret,
+        scope: auth.oauth.scope,
+      });
+      logger.info('MCP server auth configured via authProvider (OAuth client_credentials)', {
+        server: serverName,
+        clientId: auth.oauth.clientId,
+        clientSecretEnvVar: auth.oauth.clientSecretEnvVar,
+        scope: auth.oauth.scope,
+      });
+    } else {
+      logger.warn('MCP server OAuth clientSecretEnvVar configured but env var is empty', {
+        server: serverName,
+        clientId: auth.oauth.clientId,
+        envVar: auth.oauth.clientSecretEnvVar,
       });
     }
   }
@@ -238,6 +348,24 @@ export class McpClientManager {
         }
         if (s.auth.headersEnvVar && typeof s.auth.headersEnvVar === 'string') {
           auth.headersEnvVar = s.auth.headersEnvVar;
+        }
+        // M4: OAuth client_credentials config
+        if (s.auth.oauth && typeof s.auth.oauth === 'object') {
+          if (!s.auth.oauth.clientId || typeof s.auth.oauth.clientId !== 'string') {
+            throw new Error(
+              `MCP server at index ${index} (${s.name || 'unnamed'}) auth.oauth is missing required 'clientId' field`
+            );
+          }
+          if (!s.auth.oauth.clientSecretEnvVar || typeof s.auth.oauth.clientSecretEnvVar !== 'string') {
+            throw new Error(
+              `MCP server at index ${index} (${s.name || 'unnamed'}) auth.oauth is missing required 'clientSecretEnvVar' field`
+            );
+          }
+          auth.oauth = {
+            clientId: s.auth.oauth.clientId,
+            clientSecretEnvVar: s.auth.oauth.clientSecretEnvVar,
+            scope: typeof s.auth.oauth.scope === 'string' ? s.auth.oauth.scope : undefined,
+          };
         }
       }
 

--- a/src/core/mcp-client-types.ts
+++ b/src/core/mcp-client-types.ts
@@ -17,10 +17,11 @@ export type McpAttachableOperation = 'remediate' | 'operate' | 'query';
 /**
  * Authentication configuration for an MCP server connection.
  *
- * Three modes are supported:
+ * Four modes are supported:
  * 1. Static token via `tokenEnvVar` — reads bearer token from env var, passed as authProvider
  * 2. Custom headers via `headersEnvVar` — reads JSON headers from env var, passed as requestInit
- * 3. No auth (omit `auth`) — current behavior, backward compatible
+ * 3. OAuth via `oauth` — client_credentials grant using the MCP SDK's OAuthClientProvider
+ * 4. No auth (omit `auth`) — current behavior, backward compatible
  *
  * Credentials are injected via environment variables sourced from K8s Secrets.
  * Never store tokens in ConfigMaps or Helm values.
@@ -45,6 +46,36 @@ export interface McpServerAuthConfig {
    * Example env var: MCP_HEADERS_LEGACY_SERVER={"X-API-Key":"abc123"}
    */
   headersEnvVar?: string;
+
+  /**
+   * OAuth client_credentials configuration for MCP-spec-compliant servers.
+   * Uses the MCP SDK's OAuthClientProvider interface with client_credentials grant.
+   * The SDK handles discovery (RFC 9728), token exchange, and automatic refresh.
+   *
+   * PRD #414: MCP Client Outbound Authentication (M4)
+   */
+  oauth?: McpOAuthConfig;
+}
+
+/**
+ * OAuth client_credentials configuration for outbound MCP connections.
+ *
+ * dot-ai acts as an OAuth client authenticating to an MCP server's authorization
+ * server using the client_credentials grant (non-interactive, server-to-server).
+ * The MCP SDK discovers the authorization server via RFC 9728 metadata.
+ */
+export interface McpOAuthConfig {
+  /** OAuth client ID for this MCP server connection */
+  clientId: string;
+
+  /**
+   * Environment variable name containing the OAuth client secret.
+   * Example: MCP_OAUTH_SECRET_DOT_AI_UPSTREAM
+   */
+  clientSecretEnvVar: string;
+
+  /** Optional OAuth scope to request (e.g., "mcp:tools mcp:read") */
+  scope?: string;
 }
 
 /**

--- a/tests/unit/core/mcp-client-auth.test.ts
+++ b/tests/unit/core/mcp-client-auth.test.ts
@@ -8,6 +8,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   StaticTokenAuthProvider,
+  ClientCredentialsAuthProvider,
   resolveTransportAuth,
 } from '../../../src/core/mcp-client-manager.js';
 import { McpClientManager } from '../../../src/core/mcp-client-manager.js';
@@ -197,6 +198,184 @@ describe('resolveTransportAuth (M1 + M2)', () => {
       expect(result.authProvider).toBeDefined();
       expect(result.requestInit).toEqual({ headers: { 'X-Custom': 'value' } });
     });
+  });
+});
+
+describe('ClientCredentialsAuthProvider (M4)', () => {
+  test('should return undefined redirectUrl (non-interactive)', () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+    expect(provider.redirectUrl).toBeUndefined();
+  });
+
+  test('should return client metadata with client_credentials grant', () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+    expect(provider.clientMetadata.grant_types).toContain('client_credentials');
+    expect(provider.clientMetadata.client_name).toBe('dot-ai');
+  });
+
+  test('should return pre-registered client information', () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'my-client-id',
+      clientSecret: 'my-secret',
+    });
+    const info = provider.clientInformation();
+    expect(info).toBeDefined();
+    expect(info!.client_id).toBe('my-client-id');
+    expect(info!.client_secret).toBe('my-secret');
+    expect(info!.grant_types).toContain('client_credentials');
+  });
+
+  test('should return undefined tokens initially', async () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test',
+      clientSecret: 'secret',
+    });
+    const tokens = await provider.tokens();
+    expect(tokens).toBeUndefined();
+  });
+
+  test('should cache tokens after saveTokens', async () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test',
+      clientSecret: 'secret',
+    });
+    const testTokens = { access_token: 'new-access-token', token_type: 'bearer' as const };
+    await provider.saveTokens(testTokens);
+    const tokens = await provider.tokens();
+    expect(tokens).toEqual(testTokens);
+  });
+
+  test('prepareTokenRequest should return client_credentials grant type', () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test',
+      clientSecret: 'secret',
+    });
+    const params = provider.prepareTokenRequest();
+    expect(params.get('grant_type')).toBe('client_credentials');
+  });
+
+  test('prepareTokenRequest should include scope when configured', () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test',
+      clientSecret: 'secret',
+      scope: 'mcp:tools mcp:read',
+    });
+    const params = provider.prepareTokenRequest();
+    expect(params.get('grant_type')).toBe('client_credentials');
+    expect(params.get('scope')).toBe('mcp:tools mcp:read');
+  });
+
+  test('prepareTokenRequest should use argument scope over configured scope', () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test',
+      clientSecret: 'secret',
+      scope: 'default-scope',
+    });
+    const params = provider.prepareTokenRequest('override-scope');
+    expect(params.get('scope')).toBe('override-scope');
+  });
+
+  test('should save and return client information', async () => {
+    const provider = new ClientCredentialsAuthProvider({
+      clientId: 'test',
+      clientSecret: 'secret',
+    });
+    const newInfo = {
+      client_id: 'dynamic-id',
+      client_secret: 'dynamic-secret',
+      client_id_issued_at: 12345,
+      redirect_uris: [],
+    } as any;
+    await provider.saveClientInformation(newInfo);
+    expect(provider.clientInformation()).toEqual(newInfo);
+  });
+});
+
+describe('resolveTransportAuth OAuth (M4)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('should create ClientCredentialsAuthProvider when oauth configured', () => {
+    process.env.MCP_OAUTH_SECRET_TEST = 'my-client-secret';
+    const auth: McpServerAuthConfig = {
+      oauth: {
+        clientId: 'test-client',
+        clientSecretEnvVar: 'MCP_OAUTH_SECRET_TEST',
+      },
+    };
+    const result = resolveTransportAuth(auth, 'test-server', mockLogger);
+
+    expect(result.authProvider).toBeDefined();
+    expect(result.authProvider).toBeInstanceOf(ClientCredentialsAuthProvider);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'MCP server auth configured via authProvider (OAuth client_credentials)',
+      expect.objectContaining({
+        server: 'test-server',
+        clientId: 'test-client',
+      })
+    );
+  });
+
+  test('should warn when OAuth client secret env var is empty', () => {
+    delete process.env.MCP_OAUTH_SECRET_MISSING;
+    const auth: McpServerAuthConfig = {
+      oauth: {
+        clientId: 'test-client',
+        clientSecretEnvVar: 'MCP_OAUTH_SECRET_MISSING',
+      },
+    };
+    const result = resolveTransportAuth(auth, 'test-server', mockLogger);
+
+    expect(result.authProvider).toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'MCP server OAuth clientSecretEnvVar configured but env var is empty',
+      expect.objectContaining({ server: 'test-server' })
+    );
+  });
+
+  test('OAuth should take precedence over static token when both configured', () => {
+    process.env.MCP_AUTH_PRECEDENCE = 'static-token';
+    process.env.MCP_OAUTH_SECRET_PRECEDENCE = 'oauth-secret';
+    const auth: McpServerAuthConfig = {
+      tokenEnvVar: 'MCP_AUTH_PRECEDENCE',
+      oauth: {
+        clientId: 'oauth-client',
+        clientSecretEnvVar: 'MCP_OAUTH_SECRET_PRECEDENCE',
+      },
+    };
+    const result = resolveTransportAuth(auth, 'test-server', mockLogger);
+
+    // OAuth is processed after token, so it overwrites authProvider
+    expect(result.authProvider).toBeInstanceOf(ClientCredentialsAuthProvider);
+  });
+
+  test('should pass scope to ClientCredentialsAuthProvider', async () => {
+    process.env.MCP_OAUTH_SECRET_SCOPE = 'secret';
+    const auth: McpServerAuthConfig = {
+      oauth: {
+        clientId: 'test-client',
+        clientSecretEnvVar: 'MCP_OAUTH_SECRET_SCOPE',
+        scope: 'mcp:tools',
+      },
+    };
+    const result = resolveTransportAuth(auth, 'test-server', mockLogger);
+    const provider = result.authProvider as ClientCredentialsAuthProvider;
+    const params = provider.prepareTokenRequest();
+    expect(params.get('scope')).toBe('mcp:tools');
   });
 });
 

--- a/tests/unit/helm/mcp-auth.test.ts
+++ b/tests/unit/helm/mcp-auth.test.ts
@@ -190,4 +190,48 @@ describe.concurrent('MCP Server Authentication Helm Templates (PRD #414)', () =>
     expect(config[0].auth.tokenEnvVar).toBe('MCP_AUTH_MULTI_AUTH');
     expect(config[0].auth.headersEnvVar).toBe('MCP_HEADERS_MULTI_AUTH');
   });
+
+  test('auth.oauth.existingSecret injects MCP_OAUTH_SECRET_* env var from Secret (M4)', () => {
+    const docs = helmTemplate([
+      'mcpServers.upstream-ai.enabled=true',
+      'mcpServers.upstream-ai.endpoint=https://ai.example.com/mcp',
+      'mcpServers.upstream-ai.attachTo[0]=query',
+      'mcpServers.upstream-ai.auth.oauth.clientId=dot-ai-downstream',
+      'mcpServers.upstream-ai.auth.oauth.scope=mcp:tools',
+      'mcpServers.upstream-ai.auth.oauth.existingSecret.name=upstream-oauth',
+      'mcpServers.upstream-ai.auth.oauth.existingSecret.key=client-secret',
+    ]);
+
+    const deployments = findResourcesByKind<DeploymentResource>(docs, 'Deployment');
+    const mainDeploy = deployments.find(d => !d.metadata.name.includes('plugin') && !d.metadata.name.includes('dex'));
+    const container = mainDeploy!.spec.template.spec.containers.find(c => c.name === 'mcp-server');
+
+    const oauthEnv = container!.env?.find(e => e.name === 'MCP_OAUTH_SECRET_UPSTREAM_AI');
+    expect(oauthEnv).toBeDefined();
+    expect(oauthEnv!.valueFrom?.secretKeyRef).toEqual({
+      name: 'upstream-oauth',
+      key: 'client-secret',
+    });
+  });
+
+  test('OAuth config in ConfigMap includes clientId, clientSecretEnvVar, and scope (M4)', () => {
+    const docs = helmTemplate([
+      'mcpServers.upstream-ai.enabled=true',
+      'mcpServers.upstream-ai.endpoint=https://ai.example.com/mcp',
+      'mcpServers.upstream-ai.attachTo[0]=query',
+      'mcpServers.upstream-ai.auth.oauth.clientId=dot-ai-downstream',
+      'mcpServers.upstream-ai.auth.oauth.scope=mcp:tools',
+      'mcpServers.upstream-ai.auth.oauth.existingSecret.name=upstream-oauth',
+      'mcpServers.upstream-ai.auth.oauth.existingSecret.key=client-secret',
+    ]);
+
+    const configMaps = findResourcesByKind<ConfigMapResource>(docs, 'ConfigMap');
+    const mcpCm = configMaps.find(cm => cm.metadata.name.includes('mcp-servers'));
+    const config = JSON.parse(mcpCm!.data['mcp-servers.json']);
+
+    expect(config[0].auth.oauth).toBeDefined();
+    expect(config[0].auth.oauth.clientId).toBe('dot-ai-downstream');
+    expect(config[0].auth.oauth.clientSecretEnvVar).toBe('MCP_OAUTH_SECRET_UPSTREAM_AI');
+    expect(config[0].auth.oauth.scope).toBe('mcp:tools');
+  });
 });


### PR DESCRIPTION
## Summary

Add outbound authentication support for MCP client connections, enabling dot-ai to connect to MCP servers that require authorization (e.g., Context Forge, secured gateways, OAuth-protected services).

Closes #414

## What

Three SDK-native authentication modes for MCP server connections:

- **Static token (`authProvider`)**: Bearer tokens read from environment variables, passed to `StreamableHTTPClientTransport` via a `StaticTokenAuthProvider` implementing the MCP SDK's `OAuthClientProvider` interface. For MCP-spec-compliant servers requiring JWT or API key auth.

- **Custom headers (`requestInit.headers`)**: JSON-encoded HTTP headers read from environment variables, passed via `requestInit`. For non-spec servers requiring custom auth headers (e.g., `X-API-Key`).

- **OAuth client_credentials (`authProvider`)**: OAuth 2.0 client_credentials grant for server-to-server auth via `ClientCredentialsAuthProvider` implementing the MCP SDK's `OAuthClientProvider` interface. Supports RFC 9728 discovery, configurable scope, and in-memory token caching. Client ID in Helm values; client secret in K8s Secrets.

## Why

PR #410 implemented in-cluster trust for MCP connections, but many production deployments require authentication:
- Zero-trust environments where all service-to-service traffic must be authenticated
- MCP gateways that federate access to multiple backend tools
- External MCP servers requiring API keys or JWTs
- OAuth-protected MCP servers requiring client_credentials grants (e.g., upstream AI services)

## How

### Source changes
- `src/core/mcp-client-types.ts`: Added `McpServerAuthConfig` interface with `tokenEnvVar`, `headersEnvVar`, and `oauth` fields. Added `McpOAuthConfig` interface.
- `src/core/mcp-client-manager.ts`: Added `StaticTokenAuthProvider`, `ClientCredentialsAuthProvider`, and `resolveTransportAuth()`. Updated `connectAndDiscover()` to pass auth options to transport. Updated `parseMcpServerConfig()` to parse all auth config variants.

### Helm chart changes
- `charts/values.yaml`: Added `auth.token.existingSecret`, `auth.headers.existingSecret`, and `auth.oauth` (clientId, scope, existingSecret) configuration for MCP servers
- `charts/templates/_helpers.tpl`: Updated `mcpServersConfig` helper to include auth env var names and OAuth config in JSON
- `charts/templates/deployment.yaml`: Inject `MCP_AUTH_*` / `MCP_HEADERS_*` / `MCP_OAUTH_SECRET_*` env vars from K8s Secrets

### Design decisions
- **Env vars from Secrets, not ConfigMaps**: Credentials are injected as environment variables sourced from K8s Secrets (encrypted at rest), never stored in ConfigMaps or Helm values
- **SDK-native only**: Uses `authProvider` and `requestInit` — the two auth mechanisms already supported by `StreamableHTTPClientTransport`. No custom auth plumbing.
- **OAuth precedence**: When both static token and OAuth are configured, OAuth takes precedence (processed last, overwrites authProvider)
- **Backward compatible**: No auth config = no auth = current behavior unchanged

## Testing

- 31 unit tests covering all three auth modes: StaticTokenAuthProvider (5), resolveTransportAuth M1+M2 (11+combined), ClientCredentialsAuthProvider (9), resolveTransportAuth OAuth (4), type parsing (2)
- 8 Helm template unit tests verifying env var injection, ConfigMap content, OAuth injection, and backward compatibility
- `npm run lint` passes
- `npm run test:unit` passes (2 pre-existing failures in host-provider unrelated to this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server connections now support outbound authentication with three mechanisms: static bearer tokens, custom HTTP headers, and OAuth 2.0 client_credentials; configured per-server via Helm and backed by Kubernetes Secrets.

* **Documentation**
  * Updated Helm values/examples and added a changelog entry describing authentication setup and secret-backed credential usage.

* **Tests**
  * Added unit and Helm-template tests validating all authentication modes, env var injection, and behavior combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->