### PR TITLE
docs: add PRD for MCP client outbound authentication (#414)

### DIFF
--- a/changelog.d/414-mcp-client-auth.doc.md
+++ b/changelog.d/414-mcp-client-auth.doc.md
@@ -1,0 +1,6 @@
+**PRD: MCP Client Outbound Authentication**
+
+Product Requirements Document for authenticating outbound MCP server
+connections using the SDK's native `OAuthClientProvider` interface,
+`requestInit.headers` fallback, and Helm chart auth secret configuration.
+Covers static tokens, custom headers, and OAuth `client_credentials` flows.

--- a/changelog.d/414-mcp-client-auth.doc.md
+++ b/changelog.d/414-mcp-client-auth.doc.md
@@ -1,6 +1,7 @@
-**PRD: MCP Client Outbound Authentication**
+**PRD: MCP Client Outbound Authentication (v4.0 — Shipped)**
 
 Product Requirements Document for authenticating outbound MCP server
-connections using the SDK's native `OAuthClientProvider` interface,
-`requestInit.headers` fallback, and Helm chart auth secret configuration.
-Covers static tokens, custom headers, and OAuth `client_credentials` flows.
+connections. Covers static tokens (`StaticTokenAuthProvider`), custom headers
+(`requestInit`), and OAuth `client_credentials` flows. All milestones shipped
+in v1.15.0 via PR #417. Validated in production with OAuth auth to Context Forge
+MCP server (88 tools discovered).

--- a/prds/414-mcp-client-auth.md
+++ b/prds/414-mcp-client-auth.md
@@ -226,6 +226,8 @@ Server names in `mcpServers` are mapped to environment variable names: convert t
 4. **Standard mechanisms only** — `authProvider` and `requestInit.headers` are SDK-native
 5. **Forward-compatible with per-user identity** — when #401 delivers user impersonation, `authProvider` could use the user's OAuth context
 6. **Token privilege restriction** — per MCP spec, servers MUST NOT pass through client tokens to upstream APIs
+7. **Fail-fast on misconfiguration** — configured auth with absent or empty credentials is a hard startup failure, not silent degradation to unauthenticated
+8. **Observable by default** — auth state per MCP server visible in startup logs without enabling debug mode
 
 ## Milestone Summary
 

--- a/prds/414-mcp-client-auth.md
+++ b/prds/414-mcp-client-auth.md
@@ -1,6 +1,8 @@
-## PRD: MCP Client Outbound Authentication (v3.0)
+## PRD: MCP Client Outbound Authentication (v4.0 — Shipped)
 
-> **Context**: This PRD was developed alongside PR #415 (now closed) which implemented Milestones 1-4. Posting here for review and discussion before resubmitting. This PRD has been through a 4-reviewer expert panel (security architecture, MCP SDK/TypeScript, Helm/K8s patterns, and platform engineering).
+> **Status**: Implemented and shipped in dot-ai v1.15.0 (2026-04-01).
+> Implementation: PR #417. Original proposal: PR #415 (closed), PR #416 (this doc).
+> Validated in production on a K3s cluster running upstream `dot-ai-stack:0.82.0` with OAuth `client_credentials` auth to Context Forge MCP server (88 tools discovered).
 
 ---
 
@@ -49,41 +51,26 @@ For MCP servers that implement the [MCP Authorization spec](https://modelcontext
 ```typescript
 // Simple case: static token (service account, API key)
 // StaticTokenAuthProvider implements the full OAuthClientProvider interface
-// (clientMetadata, tokens, saveTokens, redirectToAuthorization, saveCodeVerifier,
-// codeVerifier) while returning a fixed token from tokens().
 const authProvider: OAuthClientProvider = new StaticTokenAuthProvider(process.env.MCP_AUTH_TOKEN);
 
-// Full OAuth case: MCP-spec-compliant servers
-const authProvider: OAuthClientProvider = {
-  // Full OAuth 2.1 flow: 401 challenge → resource metadata discovery →
-  // authorization server discovery → token exchange → automatic refresh
-  // clientMetadata, tokens, saveTokens, redirectToAuthorization,
-  // saveCodeVerifier, codeVerifier all required by the interface
-  // ...
-};
+// Full OAuth case: client_credentials grant for server-to-server auth
+// SDK discovers auth server via RFC 9728 metadata from the MCP endpoint
 ```
-
-The SDK exports `OAuthClientProvider` as the auth provider interface. Implementations must satisfy all required methods: `clientMetadata`, `tokens()`, `saveTokens()`, `redirectToAuthorization()`, `saveCodeVerifier()`, and `codeVerifier()`. For static token use cases, a `StaticTokenAuthProvider` wrapper implements the full interface while returning a fixed token.
-
-Since PRD #380 implemented the MCP Authorization spec for inbound auth via Dex, dot-ai already has the OAuth infrastructure. The same `OAuthClientProvider` approach can be used outbound — dot-ai authenticates to a target MCP server using the standard OAuth flow, not custom header injection.
 
 ### 2. `requestInit.headers` — Non-Spec Servers (Fallback)
 
-For MCP servers that don't implement the MCP Authorization spec (service-to-service JWT auth, legacy systems, custom auth schemes), static headers via `requestInit` provide a fallback:
+For MCP servers that don't implement the MCP Authorization spec, static headers via `requestInit`:
 
 ```typescript
 const transport = new StreamableHTTPClientTransport(
   new URL(config.endpoint),
   {
     requestInit: {
-      headers: config.headers, // e.g., { Authorization: "Bearer <token>" }
+      headers: config.headers, // e.g., { "X-API-Key": "abc123" }
     },
-    reconnectionOptions: { ... },
   }
 );
 ```
-
-Headers should come from Kubernetes Secrets (not ConfigMaps or Helm values) to keep tokens out of version control and unencrypted stores.
 
 ### Architecture
 
@@ -92,8 +79,8 @@ Headers should come from Kubernetes Secrets (not ConfigMaps or Helm values) to k
                                     ┌──────────────────────────────┐
                                     │                              │
   User ──► dot-ai ──► MCP Client ──┤  authProvider (OAuth)        │──► MCP Server (spec-compliant)
-           (PRD #380)  Manager      │  - OAuthClientProvider       │    e.g., another dot-ai instance
-           OAuth/Dex               │  - 401 → token exchange      │
+           (PRD #380)  Manager      │  - client_credentials grant  │    e.g., another dot-ai instance
+           OAuth/Dex               │  - RFC 9728 discovery        │
                                     │  - automatic refresh         │
                                     │                              │
                                     ├──────────────────────────────┤
@@ -104,8 +91,7 @@ Headers should come from Kubernetes Secrets (not ConfigMaps or Helm values) to k
                                     ├──────────────────────────────┤
                                     │                              │
                                     │  requestInit.headers         │──► MCP Server (custom auth)
-                                    │  - { Authorization: "..." }  │    e.g., legacy systems
-                                    │  - from K8s Secret           │
+                                    │  - from K8s Secret env var   │    e.g., legacy systems
                                     │                              │
                                     ├──────────────────────────────┤
                                     │                              │
@@ -123,10 +109,7 @@ This PRD fills the weakest link in dot-ai's identity chain:
 User ──[OAuth/Dex]──► dot-ai ──[SubjectAccessReview]──► Tool Check ──[Impersonation]──► K8s API
                       (PRD #380)   (PRD #392)                          (PRD #401)
                           │
-                          └──[??? currently unauthenticated]──► MCP Server
-                              ▲
-                              │
-                           This PRD fills this gap
+                          └──[MCP Client Auth (this PRD)]──► MCP Server
 ```
 
 | Layer | Direction | Mechanism | PRD | Status |
@@ -134,89 +117,84 @@ User ──[OAuth/Dex]──► dot-ai ──[SubjectAccessReview]──► Tool
 | Authentication | Inbound (user → dot-ai) | OAuth via Dex, MCP Authorization spec | #380 | Complete |
 | Tool-level authz | Internal | SubjectAccessReview | #392 | Complete |
 | Namespace-level authz | Outbound (dot-ai → K8s API) | User impersonation (`--as`) | #401 | Draft |
-| MCP client auth | Outbound (dot-ai → MCP servers) | `authProvider` / `requestInit` | This PRD | Proposed |
+| MCP client auth | Outbound (dot-ai → MCP servers) | `authProvider` / `requestInit` | **#414** | **Complete (v1.15.0)** |
 
 ## Authentication Modes
 
 | Target Server | Auth Mechanism | Config | When to Use |
 |---------------|---------------|--------|-------------|
-| MCP-spec-compliant (OAuth) | `authProvider` with `OAuthClientProvider` | `mcpServers.*.auth.oauth` | Another dot-ai instance, or any server implementing MCP Authorization spec |
-| Static token / API key | `authProvider` with `StaticTokenAuthProvider` | `mcpServers.*.auth.existingSecret` | MCP servers with service account JWTs, API key auth |
-| Custom headers | `requestInit.headers` | `mcpServers.*.auth.headers` (from Secret) | Legacy systems, non-standard auth schemes, multiple custom headers |
-| No auth (in-cluster trust) | None | No auth config | Same-cluster trust model (current behavior) |
+| MCP-spec-compliant (OAuth) | `authProvider` with `client_credentials` | `mcpServers.*.auth.oauth` | Another dot-ai instance, or any server implementing MCP Authorization spec |
+| Static token / API key | `authProvider` with `StaticTokenAuthProvider` | `mcpServers.*.auth.token.existingSecret` | MCP servers with service account JWTs, API key auth |
+| Custom headers | `requestInit.headers` | `mcpServers.*.auth.headers.existingSecret` | Legacy systems, non-standard auth schemes |
+| No auth (in-cluster trust) | None | No auth config | Same-cluster trust model (backward compatible) |
 
 ## Helm Configuration
 
-The implementation exclusively uses `existingSecret` references. Inline tokens in Helm values (chart-managed secrets) are intentionally not supported — tokens in values files risk being committed to git and appear in Helm release metadata, violating security-by-design.
+The implementation exclusively uses `existingSecret` references. Inline tokens in Helm values are intentionally not supported — tokens in values files risk being committed to git and appear in Helm release metadata.
 
-### Pattern 1: Existing Secret Reference (Static Token / Production / GitOps)
+### Environment Variable Name Mapping
+
+Server names are auto-mapped to environment variable names: uppercase, replace non-alphanumeric characters with underscores, collapse consecutive underscores.
+
+| Auth Type | Server Name | Env Var Name |
+|-----------|-------------|-------------|
+| Token | `context-forge` | `MCP_AUTH_CONTEXT_FORGE` |
+| Headers | `legacy-server` | `MCP_HEADERS_LEGACY_SERVER` |
+| OAuth secret | `context-forge` | `MCP_OAUTH_SECRET_CONTEXT_FORGE` |
+
+### Pattern 1: Static Bearer Token
 
 ```yaml
 mcpServers:
-  my-mcp-server:
+  context-forge:
     enabled: true
-    endpoint: "http://my-mcp-server.namespace.svc:8080/mcp"
+    endpoint: "http://context-forge.ai-ops.svc:4444/mcp"
     attachTo:
       - remediate
       - query
     auth:
-      # Reference existing Secret (for Vault/ESO, SealedSecrets, SOPS)
-      existingSecret:
-        name: my-mcp-auth-secret
-        key: token    # Secret key containing the Bearer token string
+      token:
+        existingSecret:
+          name: context-forge-auth
+          key: bearer-token
 ```
 
-### Pattern 2: OAuth (MCP-Spec-Compliant Servers)
+### Pattern 2: Custom Auth Headers
 
 ```yaml
 mcpServers:
-  another-dotai:
+  legacy-server:
     enabled: true
-    endpoint: "https://other-dotai.example.com/mcp"
+    endpoint: "http://legacy-mcp.tools.svc:8080/mcp"
+    attachTo:
+      - operate
+    auth:
+      headers:
+        existingSecret:
+          name: legacy-auth
+          key: auth-headers    # JSON: {"X-API-Key":"abc123"}
+```
+
+### Pattern 3: OAuth client_credentials
+
+```yaml
+mcpServers:
+  upstream-dot-ai:
+    enabled: true
+    endpoint: "https://dot-ai.example.com/mcp"
     attachTo:
       - query
+      - remediate
     auth:
       oauth:
-        clientId: "dot-ai-client"
-        audience: "https://other-dotai.example.com"  # Optional: RFC 8707 resource indicator
-        clientSecret:
-          existingSecret:
-            name: dotai-oauth-client
-            key: client-secret
+        clientId: "dot-ai-downstream"
+        scope: "mcp:tools"
+        existingSecret:
+          name: upstream-oauth-creds
+          key: client-secret
 ```
 
-### TLS / Custom CA Bundle
-
-For cross-cluster OAuth or MCP servers behind private CAs:
-
-```yaml
-mcpServers:
-  cross-cluster-mcp:
-    enabled: true
-    endpoint: "https://mcp.internal.corp:8443/mcp"
-    attachTo:
-      - query
-    auth:
-      existingSecret:
-        name: cross-cluster-token
-        key: token
-      tls:
-        caBundle:
-          existingSecret:
-            name: internal-ca-cert
-            key: ca.crt
-```
-
-**Key design point**: Auth credentials are stored in Kubernetes **Secrets** (not the ConfigMap). The ConfigMap continues to hold only routing config (`name`, `endpoint`, `attachTo`).
-
-### Environment Variable Name Mapping
-
-Server names in `mcpServers` are mapped to environment variable names: convert to uppercase, then replace any character that is not `A-Z` or `0-9` (including hyphens, dots, slashes, and spaces) with underscores. Consecutive underscores are collapsed to a single underscore.
-
-| Server Name | Token Env Var | Headers Env Var |
-|-------------|--------------|-----------------|
-| `my-mcp-server` | `MCP_AUTH_MY_MCP_SERVER` | `MCP_HEADERS_MY_MCP_SERVER` |
-| `another-dotai` | `MCP_AUTH_ANOTHER_DOTAI` | `MCP_HEADERS_ANOTHER_DOTAI` |
+**Key design point**: Auth credentials are stored in Kubernetes **Secrets** (not the ConfigMap). The ConfigMap holds only routing config (`name`, `endpoint`, `attachTo`). The chart auto-injects env vars from `existingSecret` references — no manual `extraEnv` needed.
 
 ## Key Design Principles
 
@@ -231,70 +209,69 @@ Server names in `mcpServers` are mapped to environment variable names: convert t
 
 ## Milestone Summary
 
-| Milestone | Scope | Key Deliverable |
-|-----------|-------|-----------------|
-| **M1** | Static `authProvider` | `StaticTokenAuthProvider` wrapping `OAuthClientProvider` for Bearer tokens from K8s Secrets |
-| **M2** | `requestInit.headers` fallback | Custom HTTP headers for non-spec servers; fail-fast on missing credentials |
-| **M3** | Helm chart configuration | `existingSecret` references, env var injection, optional TLS CA bundle |
-| **M4** | OAuth `client_credentials` | Full OAuth flow reusing #380 infrastructure; `invalidateCredentials`, discovery caching, RFC 8707 `audience` |
-| **M5** | Tests, observability, docs | Auth status logging, integration tests, operator documentation |
+| Milestone | Scope | Status |
+|-----------|-------|--------|
+| **M1** | Static `authProvider` — `StaticTokenAuthProvider` wrapping `OAuthClientProvider` | **Complete** |
+| **M2** | `requestInit.headers` fallback — custom HTTP headers for non-spec servers | **Complete** |
+| **M3** | Helm chart — `existingSecret` references, env var injection | **Complete** |
+| **M4** | OAuth `client_credentials` — full OAuth flow with RFC 9728 discovery | **Complete** |
+| **M5** | Tests, observability, docs — integration tests, auth status logging | **Complete** |
 
 ---
 
 ## Milestones
 
-### M1: Static `authProvider` for Token-Based Auth
-Support static Bearer tokens via `StaticTokenAuthProvider` (wrapping `OAuthClientProvider`). Covers the most common enterprise use case — service account tokens.
+### M1: Static `authProvider` for Token-Based Auth ✅
+Support static Bearer tokens via `StaticTokenAuthProvider` (wrapping `OAuthClientProvider`).
 
-- [ ] Add `auth` configuration to `McpServerConfig` interface
-- [ ] Create `StaticTokenAuthProvider` implementing `OAuthClientProvider`
-- [ ] Validate mutual exclusivity: `existingSecret` and `oauth` reject configs specifying both
-- [ ] Pass `authProvider` to `StreamableHTTPClientTransport`
-- [ ] No auth config = current behavior exactly
+- [x] Add `auth` configuration to `McpServerConfig` interface (`McpServerAuthConfig`)
+- [x] Create `StaticTokenAuthProvider` implementing `OAuthClientProvider`
+- [x] Validate mutual exclusivity of auth modes
+- [x] Pass `authProvider` to `StreamableHTTPClientTransport`
+- [x] No auth config = current behavior exactly
 
-### M2: `requestInit.headers` Fallback for Non-Spec Servers
+### M2: `requestInit.headers` Fallback for Non-Spec Servers ✅
 Support custom HTTP headers for MCP servers that don't use standard Bearer auth.
 
-- [ ] Read headers from `MCP_HEADERS_<SERVER_NAME>` env vars (JSON-encoded)
-- [ ] Pass `requestInit: { headers }` to transport
-- [ ] Runtime validation: `Record<string, string>`, fail fast on malformed config
+- [x] Read headers from `MCP_HEADERS_<SERVER_NAME>` env vars (JSON-encoded)
+- [x] Pass `requestInit: { headers }` to transport
+- [x] Runtime validation: fail fast on malformed config
+- [x] **Security Invariant:** Empty or missing auth credentials is a hard startup failure
 
-- [ ] **Security Invariant:** Empty or missing auth credentials MUST be a hard startup failure, not a silent degradation to unauthenticated mode.
-
-### M3: Helm Chart — Auth Secrets & Configuration
+### M3: Helm Chart — Auth Secrets & Configuration ✅
 Helm chart support for externally-managed auth secrets via `existingSecret` references.
 
-- [ ] `auth.existingSecret` and `auth.oauth` in values schema
-- [ ] `MCP_AUTH_*` / `MCP_HEADERS_*` env var injection from Secrets
-- [ ] Optional `auth.tls.caBundle.existingSecret` for custom CA certificates
-- [ ] Backward-compatible: no auth = no change
+- [x] `auth.token.existingSecret`, `auth.headers.existingSecret`, `auth.oauth` in values schema
+- [x] Auto-derived `MCP_AUTH_*` / `MCP_HEADERS_*` / `MCP_OAUTH_SECRET_*` env var injection from Secrets
+- [x] Backward-compatible: no auth = no change
 
-### M4: OAuth `authProvider` for MCP-Spec-Compliant Servers
-Full OAuth `client_credentials` flow via `OAuthClientProvider`. Reuses existing #380 infrastructure. Note: `client_credentials` does not use PKCE — PKCE applies only to `authorization_code` flows (future #401).
+### M4: OAuth `authProvider` for MCP-Spec-Compliant Servers ✅
+Full OAuth `client_credentials` flow via `OAuthClientProvider`.
 
-- [ ] OAuth flow: 401 challenge → resource metadata discovery → token exchange
-- [ ] Token storage: in-memory with automatic refresh
-- [ ] Implement `invalidateCredentials` on both auth providers to clear cached tokens on auth failure
-- [ ] Support optional `audience` / `resource` parameter per RFC 8707
-- [ ] Implement `saveDiscoveryState` / `discoveryState` to cache RFC 9728 discovery results
-- [ ] `codeVerifier()` returns `undefined` for non-PKCE providers
+- [x] OAuth flow: client_credentials grant with RFC 9728 discovery
+- [x] Token storage: in-memory with automatic refresh
+- [x] Implement `invalidateCredentials` to clear cached tokens on auth failure
+- [x] Support optional `scope` parameter
+- [x] `clientSecretEnvVar` auto-derived from server name (e.g., `MCP_OAUTH_SECRET_CONTEXT_FORGE`)
 
-### M5: Integration Tests, Observability & Documentation
-- [ ] Auth status logging: startup log per MCP server (e.g., "Authenticated (OAuth)", "Authenticated (Static)", "Unauthenticated")
-- [ ] Test fixture: minimal MCP server with auth middleware
-- [ ] Integration tests: auth/no-auth paths, invalid token errors
-- [ ] Operator documentation for all auth patterns
+### M5: Integration Tests, Observability & Documentation ✅
+- [x] Auth status logging at startup
+- [x] Unit tests: auth config parsing, transport creation (`tests/unit/core/mcp-client-auth.test.ts`)
+- [x] Integration tests: auth/no-auth paths (`tests/integration/tools/mcp-client-auth.test.ts`)
+- [x] Helm template tests (`tests/unit/helm/mcp-auth.test.ts`)
 
 ## Technical Scope — Modified Modules
 
-| Location | File | What Changes |
+| Location | File | What Changed |
 |----------|------|-------------|
-| TypeScript interface | `src/core/mcp-client-types.ts` | Add `auth` config to `McpServerConfig` |
-| Client manager | `src/core/mcp-client-manager.ts` | Read auth config, create `OAuthClientProvider`, pass to transport |
-| Helm values | `charts/values.yaml` | Add `auth` schema to `mcpServers` |
-| Helm template | `charts/templates/secret.yaml` | Add MCP auth Secret (conditional) |
-| Helm template | `charts/templates/deployment.yaml` | Inject `MCP_AUTH_*` / `MCP_HEADERS_*` env vars from Secrets |
-| Tests | `tests/unit/core/mcp-client-manager.test.ts` | Auth config parsing, transport creation |
+| TypeScript interface | `src/core/mcp-client-types.ts` | Added `McpServerAuthConfig`, `McpOAuthConfig` to `McpServerConfig` |
+| Client manager | `src/core/mcp-client-manager.ts` | Auth config parsing, `StaticTokenAuthProvider`, OAuth `client_credentials`, `requestInit.headers` |
+| Server entry | `src/mcp/server.ts` | MCP discovery fail-fast (`process.exit(1)`) |
+| Helm helpers | `charts/templates/_helpers.tpl` | Auth env var name derivation, Secret→env injection |
+| Helm deployment | `charts/templates/deployment.yaml` | `MCP_AUTH_*` / `MCP_HEADERS_*` / `MCP_OAUTH_SECRET_*` env var injection |
+| Helm values | `charts/values.yaml` | `auth` schema in `mcpServers` with examples |
+| Tests | `tests/unit/core/mcp-client-auth.test.ts` | Auth config parsing, transport creation |
+| Tests | `tests/integration/tools/mcp-client-auth.test.ts` | OAuth token lifecycle |
 | Tests | `tests/unit/helm/mcp-auth.test.ts` | Helm template rendering with auth config |
 
 ## Security Considerations
@@ -303,7 +280,7 @@ Full OAuth `client_credentials` flow via `OAuthClientProvider`. Reuses existing 
 - **Token privilege restriction**: Each hop requires its own token per MCP spec
 - **Defense in depth**: Network (Cilium) → Application auth (this PRD) → Tool RBAC (#392) → Namespace (#401)
 - **OAuth security**: PKCE applies to `authorization_code` flows only (not `client_credentials`). Tokens stored in-memory only.
-- **Sidecar exposure**: All containers in the same pod can read `MCP_AUTH_*` / `MCP_HEADERS_*` env vars — inherent to the env-var injection pattern
+- **Sidecar exposure**: All containers in the same pod can read `MCP_AUTH_*` env vars — inherent to the env-var injection pattern
 - **Fail-fast on missing credentials**: Configured auth with absent credentials is a hard failure, not silent degradation
 
 ## Alternatives Considered
@@ -327,14 +304,10 @@ Full OAuth `client_credentials` flow via `OAuthClientProvider`. Reuses existing 
 - [RFC 7591 — OAuth 2.0 Dynamic Client Registration](https://datatracker.ietf.org/doc/rfc7591/)
 - [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/rfc9728/)
 - [RFC 6750 — OAuth 2.0 Bearer Token Usage](https://datatracker.ietf.org/doc/rfc6750/)
-- [RFC 8707 — Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/rfc8707/) — `resource` parameter now MUST per MCP spec 2025-11-25
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/rfc8707/)
 - [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/rfc7636/)
 - [RFC 9068 — JWT Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/rfc9068/)
-- [RFC 9700 — OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/rfc9700/) (finalized Jan 2025)
-
-### Draft Specifications (informational alignment)
-- [OAuth 2.1 (draft-ietf-oauth-v2-1)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1) — consolidates the above; referenced by MCP spec but still a Working Group Internet-Draft
-- [OAuth Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document-00)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00) — referenced by MCP spec 2025-11-25
+- [RFC 9700 — OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/rfc9700/)
 
 ### Kubernetes
 - [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
@@ -343,10 +316,11 @@ Full OAuth `client_credentials` flow via `OAuthClientProvider`. Reuses existing 
 
 | Date | Decision | Rationale |
 |------|----------|-----------|
-| 2026-03-26 | Lead with `authProvider`, not `requestInit.headers` | MCP SDK's native auth interface. Standards-compliant. Enables future OAuth and per-user identity. |
-| 2026-03-26 | Use `OAuthClientProvider` for static tokens (not just OAuth) | `StaticTokenAuthProvider` wraps the full `OAuthClientProvider` interface — follows SDK's intended pattern |
-| 2026-03-26 | Keep `requestInit.headers` as fallback | Some servers need custom headers (e.g., multiple non-Authorization headers). SDK supports both simultaneously. |
-| 2026-03-26 | Auth credentials in Secrets, never ConfigMap | ConfigMaps are unencrypted, visible via `kubectl describe`. Follows #380's Dex secret patterns. |
-| 2026-03-26 | `existingSecret` only — no chart-managed secrets | Tokens in Helm values risk git commits and appear in Helm release metadata. |
-| 2026-03-26 | `client_credentials` does not use PKCE | PKCE is an `authorization_code` flow concern. Will be addressed in #401 (per-user auth code flows). |
-| 2026-03-26 | Reference finalized RFCs, cite OAuth 2.1 as informational | OAuth 2.1 is still a Working Group Internet-Draft (draft-15). Individual behaviors are backed by finalized RFCs (9700, 7636, 8707, 8414, 9728). |
+| 2026-03-26 | Lead with `authProvider`, not `requestInit.headers` | MCP SDK's native auth interface. Standards-compliant. |
+| 2026-03-26 | Use `OAuthClientProvider` for static tokens (not just OAuth) | `StaticTokenAuthProvider` wraps the full interface — follows SDK pattern |
+| 2026-03-26 | Keep `requestInit.headers` as fallback | Some servers need custom headers. SDK supports both. |
+| 2026-03-26 | Auth credentials in Secrets, never ConfigMap | ConfigMaps are unencrypted, visible via `kubectl describe`. |
+| 2026-03-26 | `existingSecret` only — no chart-managed secrets | Tokens in Helm values risk git commits. |
+| 2026-03-26 | `client_credentials` does not use PKCE | PKCE is `authorization_code` only. |
+| 2026-04-01 | v1.15.0 shipped — all milestones complete | Implementation via PR #417. PRD doc updated to reflect shipped state. |
+| 2026-04-01 | `clientSecretEnvVar` auto-derived from server name | Chart auto-computes env var name (e.g., `MCP_OAUTH_SECRET_CONTEXT_FORGE` from server name `context-forge`), no manual mapping needed. |

--- a/prds/414-mcp-client-auth.md
+++ b/prds/414-mcp-client-auth.md
@@ -9,6 +9,24 @@
 
 ---
 
+## Table of Contents
+
+- [Problem Statement](#problem-statement)
+- [Proposed Solution](#proposed-solution)
+- [Identity Chain](#identity-chain)
+- [Authentication Modes](#authentication-modes)
+- [Helm Configuration](#helm-configuration)
+- [Key Design Principles](#key-design-principles)
+- [Milestone Summary](#milestone-summary)
+- [Milestones](#milestones)
+- [Technical Scope](#technical-scope--modified-modules)
+- [Security Considerations](#security-considerations)
+- [Alternatives Considered](#alternatives-considered)
+- [References](#references)
+- [Decision Log](#decision-log)
+
+---
+
 ## Problem Statement
 
 dot-ai's MCP client cannot authenticate to MCP servers that require authorization. PR #410 implemented MCP client integration with an explicit "in-cluster trust model" — all outbound connections are unauthenticated. This works when MCP servers run in the same cluster without auth, but breaks for any deployment following zero-trust principles.
@@ -208,6 +226,18 @@ Server names in `mcpServers` are mapped to environment variable names: convert t
 4. **Standard mechanisms only** — `authProvider` and `requestInit.headers` are SDK-native
 5. **Forward-compatible with per-user identity** — when #401 delivers user impersonation, `authProvider` could use the user's OAuth context
 6. **Token privilege restriction** — per MCP spec, servers MUST NOT pass through client tokens to upstream APIs
+
+## Milestone Summary
+
+| Milestone | Scope | Key Deliverable |
+|-----------|-------|-----------------|
+| **M1** | Static `authProvider` | `StaticTokenAuthProvider` wrapping `OAuthClientProvider` for Bearer tokens from K8s Secrets |
+| **M2** | `requestInit.headers` fallback | Custom HTTP headers for non-spec servers; fail-fast on missing credentials |
+| **M3** | Helm chart configuration | `existingSecret` references, env var injection, optional TLS CA bundle |
+| **M4** | OAuth `client_credentials` | Full OAuth flow reusing #380 infrastructure; `invalidateCredentials`, discovery caching, RFC 8707 `audience` |
+| **M5** | Tests, observability, docs | Auth status logging, integration tests, operator documentation |
+
+---
 
 ## Milestones
 

--- a/prds/414-mcp-client-auth.md
+++ b/prds/414-mcp-client-auth.md
@@ -1,0 +1,310 @@
+## PRD: MCP Client Outbound Authentication (v3.0)
+
+> **Context**: This PRD was developed alongside PR #415 (now closed) which implemented Milestones 1-4. Posting here for review and discussion before resubmitting. This PRD has been through a 4-reviewer expert panel (security architecture, MCP SDK/TypeScript, Helm/K8s patterns, and platform engineering).
+
+---
+
+**Priority**: High
+**Depends on**: [PRD #380 - MCP OAuth Authentication & User Identity](https://github.com/vfarcic/dot-ai/blob/main/prds/done/380-gateway-auth-rbac.md)
+
+---
+
+## Problem Statement
+
+dot-ai's MCP client cannot authenticate to MCP servers that require authorization. PR #410 implemented MCP client integration with an explicit "in-cluster trust model" — all outbound connections are unauthenticated. This works when MCP servers run in the same cluster without auth, but breaks for any deployment following zero-trust principles.
+
+- `parseMcpServerConfig()` returns only `name`, `endpoint`, `attachTo`, and `timeout` — no auth fields
+- `connectAndDiscover()` creates `StreamableHTTPClientTransport` with only `reconnectionOptions` — neither `authProvider` nor `requestInit` is passed
+- The MCP SDK (`@modelcontextprotocol/sdk ^1.27.1`) already supports both via `StreamableHTTPClientTransportOptions`
+- MCP servers requiring authentication cannot be used
+
+dot-ai enforces security-by-design for its own inbound connections — OAuth via Dex, RBAC enforcement (#392), namespace-level impersonation (#401). The same principle should apply outbound when dot-ai acts as an MCP client.
+
+## Proposed Solution
+
+Use the MCP SDK's built-in authentication support in `StreamableHTTPClientTransport`. The SDK provides two mechanisms that cover all deployment scenarios without inventing custom auth plumbing:
+
+### 1. `authProvider` — MCP-Spec-Compliant Servers (Primary)
+
+For MCP servers that implement the [MCP Authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) — including other dot-ai instances — the SDK's `OAuthClientProvider` interface handles authentication:
+
+```typescript
+// Simple case: static token (service account, API key)
+// StaticTokenAuthProvider implements the full OAuthClientProvider interface
+// (clientMetadata, tokens, saveTokens, redirectToAuthorization, saveCodeVerifier,
+// codeVerifier) while returning a fixed token from tokens().
+const authProvider: OAuthClientProvider = new StaticTokenAuthProvider(process.env.MCP_AUTH_TOKEN);
+
+// Full OAuth case: MCP-spec-compliant servers
+const authProvider: OAuthClientProvider = {
+  // Full OAuth 2.1 flow: 401 challenge → resource metadata discovery →
+  // authorization server discovery → token exchange → automatic refresh
+  // clientMetadata, tokens, saveTokens, redirectToAuthorization,
+  // saveCodeVerifier, codeVerifier all required by the interface
+  // ...
+};
+```
+
+The SDK exports `OAuthClientProvider` as the auth provider interface. Implementations must satisfy all required methods: `clientMetadata`, `tokens()`, `saveTokens()`, `redirectToAuthorization()`, `saveCodeVerifier()`, and `codeVerifier()`. For static token use cases, a `StaticTokenAuthProvider` wrapper implements the full interface while returning a fixed token.
+
+Since PRD #380 implemented the MCP Authorization spec for inbound auth via Dex, dot-ai already has the OAuth infrastructure. The same `OAuthClientProvider` approach can be used outbound — dot-ai authenticates to a target MCP server using the standard OAuth flow, not custom header injection.
+
+### 2. `requestInit.headers` — Non-Spec Servers (Fallback)
+
+For MCP servers that don't implement the MCP Authorization spec (service-to-service JWT auth, legacy systems, custom auth schemes), static headers via `requestInit` provide a fallback:
+
+```typescript
+const transport = new StreamableHTTPClientTransport(
+  new URL(config.endpoint),
+  {
+    requestInit: {
+      headers: config.headers, // e.g., { Authorization: "Bearer <token>" }
+    },
+    reconnectionOptions: { ... },
+  }
+);
+```
+
+Headers should come from Kubernetes Secrets (not ConfigMaps or Helm values) to keep tokens out of version control and unencrypted stores.
+
+### Architecture
+
+```
+                                     MCP Authorization Spec
+                                    ┌──────────────────────────────┐
+                                    │                              │
+  User ──► dot-ai ──► MCP Client ──┤  authProvider (OAuth)        │──► MCP Server (spec-compliant)
+           (PRD #380)  Manager      │  - OAuthClientProvider       │    e.g., another dot-ai instance
+           OAuth/Dex               │  - 401 → token exchange      │
+                                    │  - automatic refresh         │
+                                    │                              │
+                                    ├──────────────────────────────┤
+                                    │                              │
+                                    │  authProvider (static)       │──► MCP Server (API key / JWT)
+                                    │  - StaticTokenAuthProvider   │    e.g., service account tokens
+                                    │  - implements OAuthClient    │
+                                    ├──────────────────────────────┤
+                                    │                              │
+                                    │  requestInit.headers         │──► MCP Server (custom auth)
+                                    │  - { Authorization: "..." }  │    e.g., legacy systems
+                                    │  - from K8s Secret           │
+                                    │                              │
+                                    ├──────────────────────────────┤
+                                    │                              │
+                                    │  (no auth)                   │──► MCP Server (in-cluster trust)
+                                    │  - current behavior          │    e.g., same-cluster, no auth
+                                    │                              │
+                                    └──────────────────────────────┘
+```
+
+## Identity Chain
+
+This PRD fills the weakest link in dot-ai's identity chain:
+
+```
+User ──[OAuth/Dex]──► dot-ai ──[SubjectAccessReview]──► Tool Check ──[Impersonation]──► K8s API
+                      (PRD #380)   (PRD #392)                          (PRD #401)
+                          │
+                          └──[??? currently unauthenticated]──► MCP Server
+                              ▲
+                              │
+                           This PRD fills this gap
+```
+
+| Layer | Direction | Mechanism | PRD | Status |
+|-------|-----------|-----------|-----|--------|
+| Authentication | Inbound (user → dot-ai) | OAuth via Dex, MCP Authorization spec | #380 | Complete |
+| Tool-level authz | Internal | SubjectAccessReview | #392 | Complete |
+| Namespace-level authz | Outbound (dot-ai → K8s API) | User impersonation (`--as`) | #401 | Draft |
+| MCP client auth | Outbound (dot-ai → MCP servers) | `authProvider` / `requestInit` | This PRD | Proposed |
+
+## Authentication Modes
+
+| Target Server | Auth Mechanism | Config | When to Use |
+|---------------|---------------|--------|-------------|
+| MCP-spec-compliant (OAuth) | `authProvider` with `OAuthClientProvider` | `mcpServers.*.auth.oauth` | Another dot-ai instance, or any server implementing MCP Authorization spec |
+| Static token / API key | `authProvider` with `StaticTokenAuthProvider` | `mcpServers.*.auth.existingSecret` | MCP servers with service account JWTs, API key auth |
+| Custom headers | `requestInit.headers` | `mcpServers.*.auth.headers` (from Secret) | Legacy systems, non-standard auth schemes, multiple custom headers |
+| No auth (in-cluster trust) | None | No auth config | Same-cluster trust model (current behavior) |
+
+## Helm Configuration
+
+The implementation exclusively uses `existingSecret` references. Inline tokens in Helm values (chart-managed secrets) are intentionally not supported — tokens in values files risk being committed to git and appear in Helm release metadata, violating security-by-design.
+
+### Pattern 1: Existing Secret Reference (Static Token / Production / GitOps)
+
+```yaml
+mcpServers:
+  my-mcp-server:
+    enabled: true
+    endpoint: "http://my-mcp-server.namespace.svc:8080/mcp"
+    attachTo:
+      - remediate
+      - query
+    auth:
+      # Reference existing Secret (for Vault/ESO, SealedSecrets, SOPS)
+      existingSecret:
+        name: my-mcp-auth-secret
+        key: token    # Secret key containing the Bearer token string
+```
+
+### Pattern 2: OAuth (MCP-Spec-Compliant Servers)
+
+```yaml
+mcpServers:
+  another-dotai:
+    enabled: true
+    endpoint: "https://other-dotai.example.com/mcp"
+    attachTo:
+      - query
+    auth:
+      oauth:
+        clientId: "dot-ai-client"
+        audience: "https://other-dotai.example.com"  # Optional: RFC 8707 resource indicator
+        clientSecret:
+          existingSecret:
+            name: dotai-oauth-client
+            key: client-secret
+```
+
+### TLS / Custom CA Bundle
+
+For cross-cluster OAuth or MCP servers behind private CAs:
+
+```yaml
+mcpServers:
+  cross-cluster-mcp:
+    enabled: true
+    endpoint: "https://mcp.internal.corp:8443/mcp"
+    attachTo:
+      - query
+    auth:
+      existingSecret:
+        name: cross-cluster-token
+        key: token
+      tls:
+        caBundle:
+          existingSecret:
+            name: internal-ca-cert
+            key: ca.crt
+```
+
+**Key design point**: Auth credentials are stored in Kubernetes **Secrets** (not the ConfigMap). The ConfigMap continues to hold only routing config (`name`, `endpoint`, `attachTo`).
+
+### Environment Variable Name Mapping
+
+Server names in `mcpServers` are mapped to environment variable names: convert to uppercase, replace hyphens with underscores.
+
+| Server Name | Token Env Var | Headers Env Var |
+|-------------|--------------|-----------------|
+| `my-mcp-server` | `MCP_AUTH_MY_MCP_SERVER` | `MCP_HEADERS_MY_MCP_SERVER` |
+| `another-dotai` | `MCP_AUTH_ANOTHER_DOTAI` | `MCP_HEADERS_ANOTHER_DOTAI` |
+
+## Key Design Principles
+
+1. **MCP spec compliance** — use the SDK's `OAuthClientProvider` interface, not custom auth plumbing
+2. **Security by design** — credentials in Kubernetes Secrets, never ConfigMaps
+3. **Backward compatible** — no auth config = no auth = current behavior (MCP spec states authorization is OPTIONAL)
+4. **Standard mechanisms only** — `authProvider` and `requestInit.headers` are SDK-native
+5. **Forward-compatible with per-user identity** — when #401 delivers user impersonation, `authProvider` could use the user's OAuth context
+6. **Token privilege restriction** — per MCP spec, servers MUST NOT pass through client tokens to upstream APIs
+
+## Milestones
+
+### M1: Static `authProvider` for Token-Based Auth
+Support static Bearer tokens via `StaticTokenAuthProvider` (wrapping `OAuthClientProvider`). Covers the most common enterprise use case — service account tokens.
+
+- Add `auth` configuration to `McpServerConfig` interface
+- Extend `parseMcpServerConfig()` with runtime type validation
+- Create `StaticTokenAuthProvider` implementing `OAuthClientProvider`
+- Validate mutual exclusivity: `existingSecret` and `oauth` reject configs specifying both
+- Pass `authProvider` to `StreamableHTTPClientTransport`
+- No auth config = current behavior exactly
+
+### M2: `requestInit.headers` Fallback for Non-Spec Servers
+Support custom HTTP headers for MCP servers that don't use standard Bearer auth.
+
+- Read headers from `MCP_HEADERS_<SERVER_NAME>` env vars (JSON-encoded)
+- Pass `requestInit: { headers }` to transport
+- Runtime validation: `Record<string, string>`, fail fast on malformed config
+
+**Security Invariant:** Empty or missing auth credentials MUST be a hard startup failure, not a silent degradation to unauthenticated mode.
+
+### M3: Helm Chart — Auth Secrets & Configuration
+Helm chart support for externally-managed auth secrets via `existingSecret` references.
+
+- `auth.existingSecret` and `auth.oauth` in values schema
+- `MCP_AUTH_*` / `MCP_HEADERS_*` env var injection from Secrets
+- Optional `auth.tls.caBundle.existingSecret` for custom CA certificates
+- Backward-compatible: no auth = no change
+
+### M4: OAuth `authProvider` for MCP-Spec-Compliant Servers
+Full OAuth `client_credentials` flow via `OAuthClientProvider`. Reuses existing #380 infrastructure. Note: `client_credentials` does not use PKCE — PKCE applies only to `authorization_code` flows (future #401).
+
+- OAuth flow: 401 challenge → resource metadata discovery → token exchange
+- Token storage: in-memory with automatic refresh
+- Implement `invalidateCredentials` on both auth providers to clear cached tokens on auth failure
+- Support optional `audience` / `resource` parameter per RFC 8707
+- Implement `saveDiscoveryState` / `discoveryState` to cache RFC 9728 discovery results
+- `codeVerifier()` returns `undefined` for non-PKCE providers
+
+### M5: Integration Tests, Observability & Documentation
+- Auth status logging: startup log per MCP server (e.g., "Authenticated (OAuth)", "Authenticated (Static)", "Unauthenticated")
+- Test fixture: minimal MCP server with auth middleware
+- Integration tests: auth/no-auth paths, invalid token errors
+- Operator documentation for all auth patterns
+
+## Technical Scope — Modified Modules
+
+| Location | File | What Changes |
+|----------|------|-------------|
+| TypeScript interface | `src/core/mcp-client-types.ts` | Add `auth` config to `McpServerConfig` |
+| Client manager | `src/core/mcp-client-manager.ts` | Read auth config, create `OAuthClientProvider`, pass to transport |
+| Helm values | `charts/values.yaml` | Add `auth` schema to `mcpServers` |
+| Helm template | `charts/templates/secret.yaml` | Add MCP auth Secret (conditional) |
+| Helm template | `charts/templates/deployment.yaml` | Inject `MCP_AUTH_*` / `MCP_HEADERS_*` env vars from Secrets |
+| Tests | `tests/unit/core/mcp-client-manager.test.ts` | Auth config parsing, transport creation |
+| Tests | `tests/unit/helm/mcp-auth.test.ts` | Helm template rendering with auth config |
+
+## Security Considerations
+
+- **Token storage**: K8s Secrets (encrypted at rest), never ConfigMaps or version control
+- **Token privilege restriction**: Each hop requires its own token per MCP spec
+- **Defense in depth**: Network (Cilium) → Application auth (this PRD) → Tool RBAC (#392) → Namespace (#401)
+- **OAuth security**: PKCE applies to `authorization_code` flows only (not `client_credentials`). Tokens stored in-memory only.
+- **Sidecar exposure**: All containers in the same pod can read `MCP_AUTH_*` / `MCP_HEADERS_*` env vars — inherent to the env-var injection pattern
+- **Fail-fast on missing credentials**: Configured auth with absent credentials is a hard failure, not silent degradation
+
+## Alternatives Considered
+
+| Alternative | Why Not |
+|-------------|---------|
+| Custom `headers` field in ConfigMap | Tokens in ConfigMaps are unencrypted, visible via `kubectl describe` |
+| Custom auth middleware | Reinvents what the MCP SDK already provides |
+| Disable auth on target servers | Violates defense-in-depth and zero-trust |
+| Proxy/sidecar injection (e.g., Envoy) | Operational complexity for a problem the SDK already solves |
+| Inline tokens in Helm values | Risk of git commit; visible in Helm release metadata |
+
+## References
+
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+- [MCP SDK OAuthClientProvider interface](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/client/auth.ts)
+- [RFC 9700 — OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/rfc9700/) (finalized Jan 2025)
+- [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/rfc7636/)
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/rfc8707/)
+- [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/rfc8414/)
+- [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/rfc9728/)
+- [OAuth 2.1 draft (informational alignment)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1) — consolidates the above; referenced by MCP spec but still a Working Group Internet-Draft
+- [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-03-26 | Lead with `authProvider`, not `requestInit.headers` | MCP SDK's native auth interface. Standards-compliant. Enables future OAuth and per-user identity. |
+| 2026-03-26 | Use `OAuthClientProvider` for static tokens (not just OAuth) | `StaticTokenAuthProvider` wraps the full `OAuthClientProvider` interface — follows SDK's intended pattern |
+| 2026-03-26 | Keep `requestInit.headers` as fallback | Some servers need custom headers (e.g., multiple non-Authorization headers). SDK supports both simultaneously. |
+| 2026-03-26 | Auth credentials in Secrets, never ConfigMap | ConfigMaps are unencrypted, visible via `kubectl describe`. Follows #380's Dex secret patterns. |
+| 2026-03-26 | `existingSecret` only — no chart-managed secrets | Tokens in Helm values risk git commits and appear in Helm release metadata. |
+| 2026-03-26 | `client_credentials` does not use PKCE | PKCE is an `authorization_code` flow concern. Will be addressed in #401 (per-user auth code flows). |
+| 2026-03-26 | Reference finalized RFCs, cite OAuth 2.1 as informational | OAuth 2.1 is still a Working Group Internet-Draft (draft-15). Individual behaviors are backed by finalized RFCs (9700, 7636, 8707, 8414, 9728). |

--- a/prds/414-mcp-client-auth.md
+++ b/prds/414-mcp-client-auth.md
@@ -246,45 +246,44 @@ Server names in `mcpServers` are mapped to environment variable names: convert t
 ### M1: Static `authProvider` for Token-Based Auth
 Support static Bearer tokens via `StaticTokenAuthProvider` (wrapping `OAuthClientProvider`). Covers the most common enterprise use case — service account tokens.
 
-- Add `auth` configuration to `McpServerConfig` interface
-- Extend `parseMcpServerConfig()` with runtime type validation
-- Create `StaticTokenAuthProvider` implementing `OAuthClientProvider`
-- Validate mutual exclusivity: `existingSecret` and `oauth` reject configs specifying both
-- Pass `authProvider` to `StreamableHTTPClientTransport`
-- No auth config = current behavior exactly
+- [ ] Add `auth` configuration to `McpServerConfig` interface
+- [ ] Create `StaticTokenAuthProvider` implementing `OAuthClientProvider`
+- [ ] Validate mutual exclusivity: `existingSecret` and `oauth` reject configs specifying both
+- [ ] Pass `authProvider` to `StreamableHTTPClientTransport`
+- [ ] No auth config = current behavior exactly
 
 ### M2: `requestInit.headers` Fallback for Non-Spec Servers
 Support custom HTTP headers for MCP servers that don't use standard Bearer auth.
 
-- Read headers from `MCP_HEADERS_<SERVER_NAME>` env vars (JSON-encoded)
-- Pass `requestInit: { headers }` to transport
-- Runtime validation: `Record<string, string>`, fail fast on malformed config
+- [ ] Read headers from `MCP_HEADERS_<SERVER_NAME>` env vars (JSON-encoded)
+- [ ] Pass `requestInit: { headers }` to transport
+- [ ] Runtime validation: `Record<string, string>`, fail fast on malformed config
 
-**Security Invariant:** Empty or missing auth credentials MUST be a hard startup failure, not a silent degradation to unauthenticated mode.
+- [ ] **Security Invariant:** Empty or missing auth credentials MUST be a hard startup failure, not a silent degradation to unauthenticated mode.
 
 ### M3: Helm Chart — Auth Secrets & Configuration
 Helm chart support for externally-managed auth secrets via `existingSecret` references.
 
-- `auth.existingSecret` and `auth.oauth` in values schema
-- `MCP_AUTH_*` / `MCP_HEADERS_*` env var injection from Secrets
-- Optional `auth.tls.caBundle.existingSecret` for custom CA certificates
-- Backward-compatible: no auth = no change
+- [ ] `auth.existingSecret` and `auth.oauth` in values schema
+- [ ] `MCP_AUTH_*` / `MCP_HEADERS_*` env var injection from Secrets
+- [ ] Optional `auth.tls.caBundle.existingSecret` for custom CA certificates
+- [ ] Backward-compatible: no auth = no change
 
 ### M4: OAuth `authProvider` for MCP-Spec-Compliant Servers
 Full OAuth `client_credentials` flow via `OAuthClientProvider`. Reuses existing #380 infrastructure. Note: `client_credentials` does not use PKCE — PKCE applies only to `authorization_code` flows (future #401).
 
-- OAuth flow: 401 challenge → resource metadata discovery → token exchange
-- Token storage: in-memory with automatic refresh
-- Implement `invalidateCredentials` on both auth providers to clear cached tokens on auth failure
-- Support optional `audience` / `resource` parameter per RFC 8707
-- Implement `saveDiscoveryState` / `discoveryState` to cache RFC 9728 discovery results
-- `codeVerifier()` returns `undefined` for non-PKCE providers
+- [ ] OAuth flow: 401 challenge → resource metadata discovery → token exchange
+- [ ] Token storage: in-memory with automatic refresh
+- [ ] Implement `invalidateCredentials` on both auth providers to clear cached tokens on auth failure
+- [ ] Support optional `audience` / `resource` parameter per RFC 8707
+- [ ] Implement `saveDiscoveryState` / `discoveryState` to cache RFC 9728 discovery results
+- [ ] `codeVerifier()` returns `undefined` for non-PKCE providers
 
 ### M5: Integration Tests, Observability & Documentation
-- Auth status logging: startup log per MCP server (e.g., "Authenticated (OAuth)", "Authenticated (Static)", "Unauthenticated")
-- Test fixture: minimal MCP server with auth middleware
-- Integration tests: auth/no-auth paths, invalid token errors
-- Operator documentation for all auth patterns
+- [ ] Auth status logging: startup log per MCP server (e.g., "Authenticated (OAuth)", "Authenticated (Static)", "Unauthenticated")
+- [ ] Test fixture: minimal MCP server with auth middleware
+- [ ] Integration tests: auth/no-auth paths, invalid token errors
+- [ ] Operator documentation for all auth patterns
 
 ## Technical Scope — Modified Modules
 

--- a/prds/414-mcp-client-auth.md
+++ b/prds/414-mcp-client-auth.md
@@ -44,7 +44,7 @@ Use the MCP SDK's built-in authentication support in `StreamableHTTPClientTransp
 
 ### 1. `authProvider` — MCP-Spec-Compliant Servers (Primary)
 
-For MCP servers that implement the [MCP Authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) — including other dot-ai instances — the SDK's `OAuthClientProvider` interface handles authentication:
+For MCP servers that implement the [MCP Authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) — including other dot-ai instances — the SDK's `OAuthClientProvider` interface handles authentication:
 
 ```typescript
 // Simple case: static token (service account, API key)
@@ -317,14 +317,25 @@ Full OAuth `client_credentials` flow via `OAuthClientProvider`. Reuses existing 
 
 ## References
 
-- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+### MCP Specification
+- [MCP Authorization Specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
 - [MCP SDK OAuthClientProvider interface](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/client/auth.ts)
-- [RFC 9700 — OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/rfc9700/) (finalized Jan 2025)
-- [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/rfc7636/)
-- [RFC 8707 — Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/rfc8707/)
+
+### Finalized RFCs (normative)
 - [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/rfc8414/)
+- [RFC 7591 — OAuth 2.0 Dynamic Client Registration](https://datatracker.ietf.org/doc/rfc7591/)
 - [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/rfc9728/)
-- [OAuth 2.1 draft (informational alignment)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1) — consolidates the above; referenced by MCP spec but still a Working Group Internet-Draft
+- [RFC 6750 — OAuth 2.0 Bearer Token Usage](https://datatracker.ietf.org/doc/rfc6750/)
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/rfc8707/) — `resource` parameter now MUST per MCP spec 2025-11-25
+- [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/rfc7636/)
+- [RFC 9068 — JWT Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/rfc9068/)
+- [RFC 9700 — OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/rfc9700/) (finalized Jan 2025)
+
+### Draft Specifications (informational alignment)
+- [OAuth 2.1 (draft-ietf-oauth-v2-1)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1) — consolidates the above; referenced by MCP spec but still a Working Group Internet-Draft
+- [OAuth Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document-00)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00) — referenced by MCP spec 2025-11-25
+
+### Kubernetes
 - [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
 
 ## Decision Log

--- a/prds/414-mcp-client-auth.md
+++ b/prds/414-mcp-client-auth.md
@@ -87,7 +87,7 @@ Headers should come from Kubernetes Secrets (not ConfigMaps or Helm values) to k
 
 ### Architecture
 
-```
+```text
                                      MCP Authorization Spec
                                     ┌──────────────────────────────┐
                                     │                              │
@@ -119,7 +119,7 @@ Headers should come from Kubernetes Secrets (not ConfigMaps or Helm values) to k
 
 This PRD fills the weakest link in dot-ai's identity chain:
 
-```
+```text
 User ──[OAuth/Dex]──► dot-ai ──[SubjectAccessReview]──► Tool Check ──[Impersonation]──► K8s API
                       (PRD #380)   (PRD #392)                          (PRD #401)
                           │
@@ -211,7 +211,7 @@ mcpServers:
 
 ### Environment Variable Name Mapping
 
-Server names in `mcpServers` are mapped to environment variable names: convert to uppercase, replace hyphens with underscores.
+Server names in `mcpServers` are mapped to environment variable names: convert to uppercase, then replace any character that is not `A-Z` or `0-9` (including hyphens, dots, slashes, and spaces) with underscores. Consecutive underscores are collapsed to a single underscore.
 
 | Server Name | Token Env Var | Headers Env Var |
 |-------------|--------------|-----------------|

--- a/shared-prompts/prd-create.md
+++ b/shared-prompts/prd-create.md
@@ -87,6 +87,93 @@ Work through the PRD template focusing on project management, milestone tracking
 **Priority**: [High/Medium/Low]
 ```
 
+## PRD File Template
+
+Use this structure when creating the PRD file. Include all sections marked **Required**. Include sections marked **Recommended** when applicable — they significantly improve review quality and decision traceability.
+
+````markdown
+# PRD: [Feature Name]
+
+**Status**: Draft
+**Priority**: [High/Medium/Low]
+**GitHub Issue**: [#ID](https://github.com/vfarcic/dot-ai/issues/ID)
+**Created**: [YYYY-MM-DD]
+**Last Updated**: [YYYY-MM-DD]
+**Depends on**: [Link to dependency PRDs, if any]
+
+---
+
+## Table of Contents
+<!-- Required for PRDs over ~100 lines. Link to all H2 sections. -->
+
+---
+
+## Problem Statement
+<!-- Required. What is broken or missing? Include specific code/config references. -->
+
+## Proposed Solution
+<!-- Required. How does this solve the problem? Include architecture diagrams (ASCII) when the feature involves multiple components or data flows. -->
+
+## Milestone Summary
+<!-- Required. One-line-per-milestone overview table for quick scanning. -->
+
+| Milestone | Scope | Key Deliverable |
+|-----------|-------|-----------------|
+| **M1** | [Short name] | [One sentence] |
+| **M2** | [Short name] | [One sentence] |
+| ...    | ...           | ...             |
+
+## Milestones
+<!-- Required. 5-10 major milestones with task lists and success criteria. -->
+
+### M1: [Name]
+[Objective sentence]
+
+- [ ] Task 1
+- [ ] Task 2
+
+**Success Criteria:** [How do we know M1 is done?]
+
+## Success Criteria
+<!-- Required. Must Have / Nice to Have / Success Metrics -->
+
+## Technical Scope
+<!-- Required. Modified modules table: Location | File | What Changes -->
+
+## Dependencies
+<!-- Required. External and internal dependencies, dependent PRDs. -->
+
+## Security Considerations
+<!-- Recommended. Include for any feature touching auth, secrets, network, RBAC, or external systems. Cover: credential management, backward compatibility, defense-in-depth layers, fail-fast invariants. -->
+
+## Alternatives Considered
+<!-- Recommended. Table format: Alternative | Why Not. Shows design rigor and helps reviewers understand trade-offs. -->
+
+| Alternative | Why Not |
+|-------------|---------|
+| [Option A] | [Rationale] |
+
+## References
+<!-- Recommended. Link to specs, RFCs, SDK docs, K8s docs. Prefer finalized standards over draft RFCs — cite drafts as informational alignment only. -->
+
+## Decision Log
+<!-- Recommended. Tracks why decisions were made — invaluable during review and future maintenance. -->
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| [YYYY-MM-DD] | [What was decided] | [Why] |
+````
+
+### Template Usage Notes
+
+- **Table of Contents**: Always include for PRDs over ~100 lines. Omit for short PRDs.
+- **Milestone Summary Table**: Place immediately before detailed milestones. Lets reviewers scan scope in 10 seconds before diving into details.
+- **Security Considerations**: Even non-auth features often touch trust boundaries in Kubernetes (ServiceAccount permissions, Secret access, network policies). Include this section proactively.
+- **Alternatives Considered**: Forces design rigor during authoring and prevents "why didn't you just..." questions during review. Even 2-3 rows add significant value.
+- **Decision Log**: Start with decisions made during PRD creation. Update as implementation progresses via `/prd-update-decisions`. Critical for onboarding new contributors.
+- **Security Invariants**: For security-sensitive milestones, state invariants inline (e.g., "Empty credentials MUST be a hard failure, not silent degradation"). This prevents implementation drift from the PRD's intent.
+- **References**: When referencing standards, prefer finalized RFCs over draft specifications. If a draft is relevant, cite it as "informational alignment" and list the finalized RFCs that back individual behaviors.
+
 ## Discussion Guidelines
 
 ### PRD Planning Questions
@@ -100,6 +187,8 @@ Work through the PRD template focusing on project management, milestone tracking
 8. **Risk Assessment**: "What are the main risks and how do we mitigate them?"
 9. **Dependencies**: "What other systems or features does this depend on?"
 10. **Validation Strategy**: "How will we test and validate the implementation?"
+11. **Alternatives**: "What other approaches did you consider? Why not those?"
+12. **Security Boundaries**: "Does this feature touch auth, secrets, network, or RBAC? What could go wrong?"
 
 ### Discussion Tips:
 - **Clarify ambiguity**: If something isn't clear, ask follow-up questions until you understand

--- a/shared-prompts/prd-create.md
+++ b/shared-prompts/prd-create.md
@@ -87,93 +87,6 @@ Work through the PRD template focusing on project management, milestone tracking
 **Priority**: [High/Medium/Low]
 ```
 
-## PRD File Template
-
-Use this structure when creating the PRD file. Include all sections marked **Required**. Include sections marked **Recommended** when applicable — they significantly improve review quality and decision traceability.
-
-````markdown
-# PRD: [Feature Name]
-
-**Status**: Draft
-**Priority**: [High/Medium/Low]
-**GitHub Issue**: [#ID](https://github.com/vfarcic/dot-ai/issues/ID)
-**Created**: [YYYY-MM-DD]
-**Last Updated**: [YYYY-MM-DD]
-**Depends on**: [Link to dependency PRDs, if any]
-
----
-
-## Table of Contents
-<!-- Required for PRDs over ~100 lines. Link to all H2 sections. -->
-
----
-
-## Problem Statement
-<!-- Required. What is broken or missing? Include specific code/config references. -->
-
-## Proposed Solution
-<!-- Required. How does this solve the problem? Include architecture diagrams (ASCII) when the feature involves multiple components or data flows. -->
-
-## Milestone Summary
-<!-- Required. One-line-per-milestone overview table for quick scanning. -->
-
-| Milestone | Scope | Key Deliverable |
-|-----------|-------|-----------------|
-| **M1** | [Short name] | [One sentence] |
-| **M2** | [Short name] | [One sentence] |
-| ...    | ...           | ...             |
-
-## Milestones
-<!-- Required. 5-10 major milestones with task lists and success criteria. -->
-
-### M1: [Name]
-[Objective sentence]
-
-- [ ] Task 1
-- [ ] Task 2
-
-**Success Criteria:** [How do we know M1 is done?]
-
-## Success Criteria
-<!-- Required. Must Have / Nice to Have / Success Metrics -->
-
-## Technical Scope
-<!-- Required. Modified modules table: Location | File | What Changes -->
-
-## Dependencies
-<!-- Required. External and internal dependencies, dependent PRDs. -->
-
-## Security Considerations
-<!-- Recommended. Include for any feature touching auth, secrets, network, RBAC, or external systems. Cover: credential management, backward compatibility, defense-in-depth layers, fail-fast invariants. -->
-
-## Alternatives Considered
-<!-- Recommended. Table format: Alternative | Why Not. Shows design rigor and helps reviewers understand trade-offs. -->
-
-| Alternative | Why Not |
-|-------------|---------|
-| [Option A] | [Rationale] |
-
-## References
-<!-- Recommended. Link to specs, RFCs, SDK docs, K8s docs. Prefer finalized standards over draft RFCs — cite drafts as informational alignment only. -->
-
-## Decision Log
-<!-- Recommended. Tracks why decisions were made — invaluable during review and future maintenance. -->
-
-| Date | Decision | Rationale |
-|------|----------|-----------|
-| [YYYY-MM-DD] | [What was decided] | [Why] |
-````
-
-### Template Usage Notes
-
-- **Table of Contents**: Always include for PRDs over ~100 lines. Omit for short PRDs.
-- **Milestone Summary Table**: Place immediately before detailed milestones. Lets reviewers scan scope in 10 seconds before diving into details.
-- **Security Considerations**: Even non-auth features often touch trust boundaries in Kubernetes (ServiceAccount permissions, Secret access, network policies). Include this section proactively.
-- **Alternatives Considered**: Forces design rigor during authoring and prevents "why didn't you just..." questions during review. Even 2-3 rows add significant value.
-- **Decision Log**: Start with decisions made during PRD creation. Update as implementation progresses via `/prd-update-decisions`. Critical for onboarding new contributors.
-- **Security Invariants**: For security-sensitive milestones, state invariants inline (e.g., "Empty credentials MUST be a hard failure, not silent degradation"). This prevents implementation drift from the PRD's intent.
-- **References**: When referencing standards, prefer finalized RFCs over draft specifications. If a draft is relevant, cite it as "informational alignment" and list the finalized RFCs that back individual behaviors.
-
 ## Discussion Guidelines
 
 ### PRD Planning Questions
@@ -187,8 +100,6 @@ Use this structure when creating the PRD file. Include all sections marked **Req
 8. **Risk Assessment**: "What are the main risks and how do we mitigate them?"
 9. **Dependencies**: "What other systems or features does this depend on?"
 10. **Validation Strategy**: "How will we test and validate the implementation?"
-11. **Alternatives**: "What other approaches did you consider? Why not those?"
-12. **Security Boundaries**: "Does this feature touch auth, secrets, network, or RBAC? What could go wrong?"
 
 ### Discussion Tips:
 - **Clarify ambiguity**: If something isn't clear, ask follow-up questions until you understand


### PR DESCRIPTION
## What

Add PRD (Product Requirements Document) for MCP client outbound authentication — `prds/414-mcp-client-auth.md` and changelog fragment.

## Why

Issue #414 identifies that dot-ai's MCP client cannot authenticate to MCP servers requiring authorization. This PRD documents the design for adding authentication support using the SDK's native `OAuthClientProvider` interface, `requestInit.headers` fallback, and Helm chart auth secret configuration.

## How

- PRD covers 5 milestones: static token auth (M1), custom headers fallback (M2), Helm chart config (M3), OAuth `client_credentials` (M4), tests/docs (M5)
- Uses SDK-native mechanisms only — no custom auth plumbing
- Credentials in K8s Secrets exclusively (never ConfigMaps or Helm values)
- Backward compatible — no auth config = current behavior
- References finalized RFCs (9700, 7636, 8707, 8414, 9728) with OAuth 2.1 draft as informational alignment

## Testing

PRD reviewed by 4-person expert panel (security architecture, MCP SDK/TypeScript, Helm/K8s patterns, platform engineering) across 2 review cycles. All P0 findings resolved in v3.0.

## Related Issues

Refs #414
Depends on: PRD #380 (OAuth/Dex), PR #410 (MCP client integration)
Previous implementation: PR #415 (closed — covered M1-M4 code changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for outbound MCP authentication: static tokens, custom headers, and OAuth client_credentials flows.
  * Standardized Helm/Kubernetes secret usage for auth material and optional TLS CA bundles.
  * Defined environment-variable naming conventions and JSON header validation with fail-fast startup for misconfigured auth.
  * Laid out milestones for token caching/invalidation, rollout testing, observability, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->