### PR TITLE
fix: Fix invalid image tag in deployment.yaml from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to a valid, publicly available nginx version allows the container to be pulled successfully and eliminates the ImagePullBackOff. Argo CD will automatically sync this change with automated sync enabled.

**Risk Level:** low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture configuration to use a valid container image reference instead of a non-existent one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->