### PR TITLE
fix: Fix the container image tag in deployment.yaml from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to a valid, stable nginx image allows the container to be pulled successfully and the pod to start running. Since Argo CD has automated sync enabled, it will automatically detect and apply this change from Git.

**Risk Level:** low