### PR TITLE
fix: Fix container image in deployment manifest to use valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from non-existent 'v999-nonexistent' to 'latest' provides a valid, pullable image that will resolve ImagePullBackOff errors. Argo CD's auto-sync will automatically apply the change.

**Risk Level:** low