### PR TITLE
fix: Fix the image tag in the deployment manifest to use a valid nginx version

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' or a specific stable version allows the container runtime to successfully pull the image and start the pod. Since Argo CD has automated sync enabled with self-healing, it will detect the Git change and automatically update the deployment.

**Risk Level:** low