### PR TITLE
fix: Fix image tag in deployment manifest from non-existent 'nginx:v999-nonexistent' to valid 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag is the direct cause of the ImagePullBackOff. Changing to 'nginx:latest' provides a valid, stable image that will resolve the pull failure. Argo CD will automatically sync the change with its automated sync policy enabled.

**Risk Level:** low