### PR TITLE
fix: Fix invalid image tag in deployment manifest and commit to Git

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag is the root cause of the ImagePullBackOff. Changing to 'nginx:latest' provides a valid, stable image. Argo CD will automatically sync the change via its automated sync policy.

**Risk Level:** low