### PR TITLE
fix: Fix invalid image tag in deployment manifest in Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from 'nginx:v999-nonexistent' to 'nginx:latest' uses a valid, existing image. Argo CD is configured with automated sync and self-heal, so it will detect and apply this change automatically within its sync interval.

**Risk Level:** low