### PR TITLE
fix: Update deployment.yaml with valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from non-existent 'v999-nonexistent' to valid 'nginx:latest' will allow Docker to successfully pull the image. Argo CD's auto-sync will immediately deploy the fix and pods will start successfully.

**Risk Level:** low