### PR TITLE
fix: Update deployment.yaml to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Replacing the non-existent 'nginx:v999-nonexistent' tag with 'nginx:latest' (or another valid version) allows the kubelet to successfully pull the image and start the container. Argo CD's automated sync will detect the change and deploy the updated manifest.

**Risk Level:** low