### PR TITLE
fix: Update deployment manifest to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from 'nginx:v999-nonexistent' (which doesn't exist) to 'nginx:latest' (which is a valid, stable tag) allows the kubelet to successfully pull the image and start the container. Argo CD will automatically sync this change due to the enabled automated sync policy.

**Risk Level:** low