### PR TITLE
fix: Fix invalid image tag in deployment manifest in the Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image from 'nginx:v999-nonexistent' to 'nginx:latest' provides a valid, publicly available container image. This allows kubelet to successfully pull the image and start pods. Argo CD's automated sync policy will detect and apply this change automatically.

**Risk Level:** low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture container image reference to use a valid and accessible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->