### PR TITLE
fix: Fix image tag in deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to a valid, existing version resolves the ImagePullBackOff error. Argo CD's automated sync policy will automatically deploy the corrected configuration to the cluster.

**Risk Level:** low