### PR TITLE
fix: Fix the invalid image tag in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from non-existent 'v999-nonexistent' to 'latest' (a valid, stable nginx image) resolves the ImagePullBackOff error. Argo CD will automatically detect the change in Git and re-sync the deployment with the corrected image.

**Risk Level:** low