### PR TITLE
fix: Fix the invalid image tag in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image from 'nginx:v999-nonexistent' to 'nginx:latest' (or another valid tag) will allow the kubelet to successfully pull the image. Argo CD's auto-sync will detect the change in Git and automatically update the deployment.

**Risk Level:** low