### PR TITLE
fix: Fix the invalid image tag in deployment.yaml manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to a valid, publicly available tag allows the kubelet to successfully pull the image and start the pods. Since Argo CD has automated sync enabled (autoSync.prune=true, autoSync.selfHeal=true), it will automatically sync this change from Git.

**Risk Level:** low