### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from 'v999-nonexistent' to 'latest' (a real, available nginx image) allows the kubelet to successfully pull the image. Since the deployment is managed by Argo CD with auto-sync enabled, it will automatically reconcile and pull the new image.

**Risk Level:** low