### PR TITLE
fix: Fix image tag in deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to a valid, stable nginx:latest version resolves the ImagePullBackOff error. This allows the container to be pulled and the pod to start successfully. Argo CD's automated sync will apply this change automatically.

**Risk Level:** low