### PR TITLE
fix: Fix the broken image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Updating the image to 'nginx:latest' uses a valid, stable tag. Since Argo CD has automated sync enabled with self-healing, it will automatically detect and apply the change, causing the deployment controller to pull the correct image and start the pods

**Risk Level:** low