### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from non-existent 'v999-nonexistent' to 'latest' resolves the ImagePullBackOff. Since the deployment has Argo CD automated sync enabled (selfHeal=true), the change will be automatically synced within the sync interval. Argo CD will also detect if the cluster differs from the source and re-apply the corrected manifest.

**Risk Level:** low