### PR TITLE
feat(query): enable AI_PROVIDER=custom + knowledge-base search from query tool

### DIFF
--- a/prompts/query-system.md
+++ b/prompts/query-system.md
@@ -1,6 +1,12 @@
 # Kubernetes Cluster Query Agent
 
-You are a read-only Kubernetes cluster analyst. Use the available tools to answer questions about cluster state, resources, and capabilities.
+You are a read-only Kubernetes cluster analyst. Use the available tools to answer questions about cluster state, resources, capabilities, and any ingested organisational documentation.
+
+## Source Selection
+
+- For questions about cluster state or configuration ("what is deployed", "how many pods", "describe the nginx deployment"), use `search_capabilities` / `query_capabilities` / `search_resources` / `query_resources` / kubectl tools.
+- For questions about internal documentation, standards, runbooks, migration notes, or "what do our docs say about X", use `search_knowledge` and cite source URIs in a "Sources:" section of your final answer.
+- For hybrid questions ("does any deployment violate our yarn4 standards?"), combine both: `search_knowledge` for the standard, then `search_resources` / `kubectl` for cluster state.
 
 ## Critical Constraint: Read-Only Operations
 

--- a/src/core/ai-provider-factory.ts
+++ b/src/core/ai-provider-factory.ts
@@ -32,6 +32,8 @@ const PROVIDER_ENV_KEYS: Record<string, string> = {
   kimi: 'MOONSHOT_API_KEY', // PRD #353: Moonshot AI Kimi K2.5
   alibaba: 'ALIBABA_API_KEY', // PRD #382: Alibaba Qwen 3.5 Plus
   xai: 'XAI_API_KEY',
+  custom: 'CUSTOM_LLM_API_KEY', // PRD #194: OpenAI-compatible custom endpoints (Ollama, vLLM, LiteLLM)
+  openrouter: 'OPENROUTER_API_KEY', // PRD #194: OpenRouter aggregator
 };
 
 /**

--- a/src/core/knowledge-tools.ts
+++ b/src/core/knowledge-tools.ts
@@ -1,0 +1,154 @@
+/**
+ * Knowledge Tools for AI-Powered Documentation Search
+ *
+ * Shared tool definitions and executor for knowledge-base (ingested docs)
+ * semantic search. Used by the `query` tool so agent loops can cite
+ * organisational documentation alongside cluster state.
+ *
+ * Re-uses the existing knowledge-base search pipeline from manage-knowledge.ts
+ * (PRD #356) rather than duplicating vector logic. Only search is exposed
+ * here — ingest/delete remain on manageKnowledge behind explicit RBAC.
+ */
+
+import { AITool } from './ai-provider.interface';
+import { searchKnowledgeBase } from '../tools/manage-knowledge';
+import { VALIDATION_MESSAGES } from './constants/validation';
+
+/**
+ * Maximum chunks per tool call. Mirrors manageKnowledge's soft cap.
+ */
+const KNOWLEDGE_SEARCH_MAX_LIMIT = 50;
+const KNOWLEDGE_SEARCH_DEFAULT_LIMIT = 10;
+
+/**
+ * Tool: search_knowledge
+ * Semantic search over ingested documentation
+ */
+export const SEARCH_KNOWLEDGE_TOOL: AITool = {
+  name: 'search_knowledge',
+  description: `Semantic search over ingested documentation (Git-sourced docs, runbooks, platform guidelines, standards, migration notes).
+
+Use this tool when the user asks about internal documentation, organisational standards, "what do our docs say about X", or needs content from GitKnowledgeSource-ingested sources. Returns ranked document chunks with the source URI and a similarity score.
+
+TIPS:
+- For complex questions, call search_knowledge multiple times with different phrasings to gather comprehensive context before synthesising an answer.
+- Cite the source URIs in your final answer under a "Sources:" section as clickable markdown links.
+- Combine with search_resources / search_capabilities for hybrid questions (e.g. "does any deployment violate our yarn4 standards?").`,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Natural-language search query (e.g. "yarn npmrc configuration", "how to bootstrap a new microservice")'
+      },
+      limit: {
+        type: 'number',
+        description: `Maximum chunks to return (default: ${KNOWLEDGE_SEARCH_DEFAULT_LIMIT}, max: ${KNOWLEDGE_SEARCH_MAX_LIMIT})`
+      },
+      uriFilter: {
+        type: 'string',
+        description: 'Optional: restrict results to chunks whose source URI exactly matches this value. Leave empty to search all sources.'
+      }
+    },
+    required: ['query']
+  }
+};
+
+/**
+ * All knowledge tools available to agent loops.
+ * Convenient array for passing to toolLoop().
+ */
+export const KNOWLEDGE_TOOLS: AITool[] = [SEARCH_KNOWLEDGE_TOOL];
+
+/**
+ * Input shape for search_knowledge
+ */
+export interface SearchKnowledgeInput {
+  query?: string;
+  limit?: number;
+  uriFilter?: string;
+}
+
+/**
+ * Tool executor for knowledge-base tools.
+ *
+ * @param toolName - Name of the tool to execute (only 'search_knowledge' supported)
+ * @param input - Tool input parameters
+ * @returns Tool execution result with a `data` payload or structured error
+ */
+export async function executeKnowledgeTools(
+  toolName: string,
+  input: SearchKnowledgeInput
+): Promise<Record<string, unknown>> {
+  if (toolName !== 'search_knowledge') {
+    return {
+      success: false,
+      error: `Unknown knowledge tool: ${toolName}`,
+      message: `Tool '${toolName}' is not implemented in knowledge tools`
+    };
+  }
+
+  try {
+    const { query, limit, uriFilter } = input ?? {};
+
+    if (!query || typeof query !== 'string') {
+      return {
+        success: false,
+        error: VALIDATION_MESSAGES.MISSING_PARAMETER('query'),
+        message: 'search_knowledge requires a query parameter'
+      };
+    }
+
+    const effectiveLimit = Math.min(
+      Math.max(1, typeof limit === 'number' ? limit : KNOWLEDGE_SEARCH_DEFAULT_LIMIT),
+      KNOWLEDGE_SEARCH_MAX_LIMIT
+    );
+
+    const result = await searchKnowledgeBase({
+      query,
+      limit: effectiveLimit,
+      uriFilter
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: result.error ?? 'Knowledge search failed',
+        message: `search_knowledge failed: ${result.error ?? 'unknown error'}`
+      };
+    }
+
+    // Shape results for AI consumption — include enough to cite but drop
+    // vector internals (id, checksum) that add noise to the agent context.
+    const chunks = result.chunks.map(chunk => ({
+      content: chunk.content,
+      uri: chunk.uri,
+      score: chunk.score,
+      matchType: chunk.matchType,
+      chunkIndex: chunk.chunkIndex,
+      totalChunks: chunk.totalChunks,
+      metadata: chunk.metadata,
+      ...(chunk.extractedPolicies ? { extractedPolicies: chunk.extractedPolicies } : {})
+    }));
+
+    return {
+      success: true,
+      data: chunks,
+      count: chunks.length,
+      totalMatches: result.totalMatches,
+      message: chunks.length > 0
+        ? `Found ${chunks.length} matching chunks for "${query}"`
+        : `No matching documents found for "${query}"`,
+      agentInstructions: chunks.length > 0
+        ? 'Synthesise an answer from the chunks. Discard irrelevant content. Append a "Sources:" section with the unique source URIs as clickable markdown links. Do NOT surface raw chunks, scores, or metadata.'
+        : undefined
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: errorMessage,
+      message: `Failed to execute ${toolName}: ${errorMessage}`
+    };
+  }
+}

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -12,6 +12,7 @@ import { ErrorHandler, ErrorCategory, ErrorSeverity, ConsoleLogger } from '../co
 import { createAIProvider } from '../core/ai-provider-factory';
 import { CAPABILITY_TOOLS, executeCapabilityTools } from '../core/capability-tools';
 import { RESOURCE_TOOLS, executeResourceTools, type SearchResourcesInput, type QueryResourcesInput } from '../core/resource-tools';
+import { KNOWLEDGE_TOOLS, executeKnowledgeTools, type SearchKnowledgeInput } from '../core/knowledge-tools';
 import { PluginManager } from '../core/plugin-manager';
 import { isMcpClientInitialized, getMcpClientManager } from '../core/mcp-client-registry';
 import { GenericSessionManager } from '../core/generic-session-manager';
@@ -190,6 +191,9 @@ export async function handleQueryTool(
       if (toolName.startsWith('search_resources') || toolName.startsWith('query_resources')) {
         return executeResourceTools(toolName, input as SearchResourcesInput | QueryResourcesInput);
       }
+      if (toolName === 'search_knowledge') {
+        return executeKnowledgeTools(toolName, input as SearchKnowledgeInput);
+      }
       if (toolName === 'validate_mermaid') {
         return executeMermaidTools(toolName, input as MermaidToolInput);
       }
@@ -233,8 +237,8 @@ export async function handleQueryTool(
     // kubectl tools only available when plugin is configured
     // MCP tools added when MCP servers are configured
     const tools = visualizationMode
-      ? [...CAPABILITY_TOOLS, ...RESOURCE_TOOLS, ...pluginKubectlTools, ...mcpTools, ...MERMAID_TOOLS]
-      : [...CAPABILITY_TOOLS, ...RESOURCE_TOOLS, ...pluginKubectlTools, ...mcpTools];
+      ? [...CAPABILITY_TOOLS, ...RESOURCE_TOOLS, ...KNOWLEDGE_TOOLS, ...pluginKubectlTools, ...mcpTools, ...MERMAID_TOOLS]
+      : [...CAPABILITY_TOOLS, ...RESOURCE_TOOLS, ...KNOWLEDGE_TOOLS, ...pluginKubectlTools, ...mcpTools];
 
     // Execute tool loop with capability, resource, kubectl, and MCP tools
     const result = await aiProvider.toolLoop({

--- a/tests/unit/core/ai-provider-factory.test.ts
+++ b/tests/unit/core/ai-provider-factory.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hoisted mocks — required because vi.mock factories execute before imports
+const {
+  mockCreateAnthropic,
+  mockCreateOpenAI,
+  mockCreateGoogleGenerativeAI,
+  mockCreateXai,
+  mockCreateAlibaba,
+  mockCreateOpenAICompatible,
+  mockCreateAmazonBedrock,
+  mockCreateOpenRouter,
+} = vi.hoisted(() => ({
+  mockCreateAnthropic: vi.fn(),
+  mockCreateOpenAI: vi.fn(),
+  mockCreateGoogleGenerativeAI: vi.fn(),
+  mockCreateXai: vi.fn(),
+  mockCreateAlibaba: vi.fn(),
+  mockCreateOpenAICompatible: vi.fn(),
+  mockCreateAmazonBedrock: vi.fn(),
+  mockCreateOpenRouter: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/anthropic', () => ({ createAnthropic: mockCreateAnthropic }));
+vi.mock('@ai-sdk/openai', () => ({ createOpenAI: mockCreateOpenAI }));
+vi.mock('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: mockCreateGoogleGenerativeAI,
+}));
+vi.mock('@ai-sdk/xai', () => ({ createXai: mockCreateXai }));
+vi.mock('@ai-sdk/alibaba', () => ({ createAlibaba: mockCreateAlibaba }));
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: mockCreateOpenAICompatible,
+}));
+vi.mock('@ai-sdk/amazon-bedrock', () => ({
+  createAmazonBedrock: mockCreateAmazonBedrock,
+}));
+vi.mock('@openrouter/ai-sdk-provider', () => ({
+  createOpenRouter: mockCreateOpenRouter,
+}));
+
+vi.mock('../../../src/core/tracing/ai-tracing', () => ({
+  withAITracing: vi.fn((_config, fn) => fn()),
+}));
+vi.mock('ai', () => ({
+  generateText: vi.fn(),
+  jsonSchema: vi.fn(),
+  tool: vi.fn(),
+  stepCountIs: vi.fn(),
+}));
+
+import { AIProviderFactory } from '../../../src/core/ai-provider-factory';
+import { NoOpAIProvider } from '../../../src/core/providers/noop-provider';
+import { VercelProvider } from '../../../src/core/providers/vercel-provider';
+
+function mockProviderFactory() {
+  const mockModel = { modelId: 'test-model' };
+  const providerFn = vi.fn().mockReturnValue(mockModel);
+  providerFn.chat = vi.fn().mockReturnValue(mockModel);
+  providerFn.chatModel = vi.fn().mockReturnValue(mockModel);
+  return providerFn;
+}
+
+describe('PRD #194: custom and openrouter providers selectable via AI_PROVIDER', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    // Ensure default selection is deterministic — strip any leaked provider env
+    delete process.env.AI_PROVIDER;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.XAI_API_KEY;
+    delete process.env.MOONSHOT_API_KEY;
+    delete process.env.ALIBABA_API_KEY;
+    delete process.env.CUSTOM_LLM_API_KEY;
+    delete process.env.CUSTOM_LLM_BASE_URL;
+    delete process.env.CUSTOM_LLM_HEADERS;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.AI_MODEL;
+
+    vi.clearAllMocks();
+
+    mockCreateAnthropic.mockReturnValue(mockProviderFactory());
+    mockCreateOpenAI.mockReturnValue(mockProviderFactory());
+    mockCreateGoogleGenerativeAI.mockReturnValue(mockProviderFactory());
+    mockCreateXai.mockReturnValue(mockProviderFactory());
+    mockCreateAlibaba.mockReturnValue(mockProviderFactory());
+    mockCreateOpenAICompatible.mockReturnValue(mockProviderFactory());
+    mockCreateAmazonBedrock.mockReturnValue(mockProviderFactory());
+    mockCreateOpenRouter.mockReturnValue(mockProviderFactory());
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe('AI_PROVIDER=custom', () => {
+    it('returns a VercelProvider when CUSTOM_LLM_API_KEY and CUSTOM_LLM_BASE_URL are set', () => {
+      process.env.AI_PROVIDER = 'custom';
+      process.env.CUSTOM_LLM_API_KEY = 'ollama-dummy-key';
+      process.env.CUSTOM_LLM_BASE_URL = 'http://host.docker.internal:11434/v1';
+      process.env.AI_MODEL = 'qwen2.5:3b';
+
+      const provider = AIProviderFactory.createFromEnv();
+
+      expect(provider).toBeInstanceOf(VercelProvider);
+      expect(provider).not.toBeInstanceOf(NoOpAIProvider);
+      // Custom provider uses the OpenAI-compatible adapter under the hood
+      expect(mockCreateOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'ollama-dummy-key',
+          baseURL: 'http://host.docker.internal:11434/v1',
+        })
+      );
+    });
+
+    it('falls back to NoOpAIProvider when CUSTOM_LLM_API_KEY is absent', () => {
+      process.env.AI_PROVIDER = 'custom';
+      delete process.env.CUSTOM_LLM_API_KEY;
+      process.env.CUSTOM_LLM_BASE_URL = 'http://host.docker.internal:11434/v1';
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+
+      const provider = AIProviderFactory.createFromEnv();
+
+      expect(provider).toBeInstanceOf(NoOpAIProvider);
+      // Messaging should reference the env var name so operators can find it
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('CUSTOM_LLM_API_KEY')
+      );
+      expect(mockCreateOpenAI).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AI_PROVIDER=openrouter', () => {
+    it('returns a VercelProvider when OPENROUTER_API_KEY is set', () => {
+      process.env.AI_PROVIDER = 'openrouter';
+      process.env.OPENROUTER_API_KEY = 'or-sk-test';
+
+      const provider = AIProviderFactory.createFromEnv();
+
+      expect(provider).toBeInstanceOf(VercelProvider);
+      expect(provider).not.toBeInstanceOf(NoOpAIProvider);
+      expect(mockCreateOpenRouter).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'or-sk-test' })
+      );
+    });
+
+    it('falls back to NoOpAIProvider when OPENROUTER_API_KEY is absent', () => {
+      process.env.AI_PROVIDER = 'openrouter';
+      delete process.env.OPENROUTER_API_KEY;
+
+      const provider = AIProviderFactory.createFromEnv();
+
+      expect(provider).toBeInstanceOf(NoOpAIProvider);
+      expect(mockCreateOpenRouter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('regression: existing providers unaffected', () => {
+    it('anthropic path still resolves ANTHROPIC_API_KEY', () => {
+      process.env.AI_PROVIDER = 'anthropic';
+      process.env.ANTHROPIC_API_KEY = 'test-key';
+
+      AIProviderFactory.createFromEnv();
+
+      expect(mockCreateAnthropic).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'test-key' })
+      );
+    });
+
+    it('google_flash path still resolves GOOGLE_GENERATIVE_AI_API_KEY', () => {
+      process.env.AI_PROVIDER = 'google_flash';
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY = 'test-key';
+
+      AIProviderFactory.createFromEnv();
+
+      expect(mockCreateGoogleGenerativeAI).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'test-key' })
+      );
+    });
+  });
+});

--- a/tests/unit/core/knowledge-tools.test.ts
+++ b/tests/unit/core/knowledge-tools.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSearchKnowledgeBase } = vi.hoisted(() => ({
+  mockSearchKnowledgeBase: vi.fn(),
+}));
+
+vi.mock('../../../src/tools/manage-knowledge', () => ({
+  searchKnowledgeBase: mockSearchKnowledgeBase,
+}));
+
+import {
+  KNOWLEDGE_TOOLS,
+  SEARCH_KNOWLEDGE_TOOL,
+  executeKnowledgeTools,
+} from '../../../src/core/knowledge-tools';
+
+describe('knowledge-tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('tool definitions', () => {
+    it('exposes exactly one tool: search_knowledge', () => {
+      expect(KNOWLEDGE_TOOLS).toHaveLength(1);
+      expect(KNOWLEDGE_TOOLS[0]).toBe(SEARCH_KNOWLEDGE_TOOL);
+      expect(SEARCH_KNOWLEDGE_TOOL.name).toBe('search_knowledge');
+    });
+
+    it('declares query as a required parameter', () => {
+      expect(SEARCH_KNOWLEDGE_TOOL.inputSchema.required).toEqual(['query']);
+      expect(SEARCH_KNOWLEDGE_TOOL.inputSchema.properties).toHaveProperty('query');
+      expect(SEARCH_KNOWLEDGE_TOOL.inputSchema.properties).toHaveProperty('limit');
+      expect(SEARCH_KNOWLEDGE_TOOL.inputSchema.properties).toHaveProperty('uriFilter');
+    });
+  });
+
+  describe('executeKnowledgeTools', () => {
+    it('rejects unknown tool names', async () => {
+      const result = await executeKnowledgeTools('search_mystery' as string, {
+        query: 'anything',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('search_mystery');
+      expect(mockSearchKnowledgeBase).not.toHaveBeenCalled();
+    });
+
+    it('returns a validation error when query is missing', async () => {
+      const result = await executeKnowledgeTools('search_knowledge', {});
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('query');
+      expect(mockSearchKnowledgeBase).not.toHaveBeenCalled();
+    });
+
+    it('dispatches to searchKnowledgeBase with clamped limit (default 10)', async () => {
+      mockSearchKnowledgeBase.mockResolvedValue({
+        success: true,
+        chunks: [],
+        totalMatches: 0,
+      });
+
+      await executeKnowledgeTools('search_knowledge', { query: 'yarn npmrc' });
+
+      expect(mockSearchKnowledgeBase).toHaveBeenCalledWith({
+        query: 'yarn npmrc',
+        limit: 10,
+        uriFilter: undefined,
+      });
+    });
+
+    it('clamps limit to the max (50) when the agent asks for more', async () => {
+      mockSearchKnowledgeBase.mockResolvedValue({
+        success: true,
+        chunks: [],
+        totalMatches: 0,
+      });
+
+      await executeKnowledgeTools('search_knowledge', {
+        query: 'anything',
+        limit: 10_000,
+      });
+
+      expect(mockSearchKnowledgeBase).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50 })
+      );
+    });
+
+    it('clamps limit to 1 when the agent asks for 0 or negative', async () => {
+      mockSearchKnowledgeBase.mockResolvedValue({
+        success: true,
+        chunks: [],
+        totalMatches: 0,
+      });
+
+      await executeKnowledgeTools('search_knowledge', {
+        query: 'anything',
+        limit: 0,
+      });
+
+      expect(mockSearchKnowledgeBase).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 1 })
+      );
+    });
+
+    it('forwards uriFilter verbatim', async () => {
+      mockSearchKnowledgeBase.mockResolvedValue({
+        success: true,
+        chunks: [],
+        totalMatches: 0,
+      });
+
+      await executeKnowledgeTools('search_knowledge', {
+        query: 'npm auth token',
+        uriFilter: 'https://git.example.com/org/platform-guidelines',
+      });
+
+      expect(mockSearchKnowledgeBase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uriFilter: 'https://git.example.com/org/platform-guidelines',
+        })
+      );
+    });
+
+    it('reshapes chunks for AI consumption (drops id/checksum, keeps citeable fields)', async () => {
+      mockSearchKnowledgeBase.mockResolvedValue({
+        success: true,
+        chunks: [
+          {
+            id: 'uuid-1',
+            content: 'Always set npmAuthToken in .npmrc',
+            score: 0.9,
+            matchType: 'semantic',
+            uri: 'https://example.com/doc.md',
+            metadata: { source: 'platform-guidelines' },
+            chunkIndex: 0,
+            totalChunks: 3,
+          },
+        ],
+        totalMatches: 1,
+      });
+
+      const result = await executeKnowledgeTools('search_knowledge', {
+        query: 'npmAuthToken',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+      expect(result.totalMatches).toBe(1);
+      expect(result.agentInstructions).toContain('Sources:');
+
+      const chunks = result.data as Array<Record<string, unknown>>;
+      expect(chunks[0]).toMatchObject({
+        content: 'Always set npmAuthToken in .npmrc',
+        uri: 'https://example.com/doc.md',
+        score: 0.9,
+        matchType: 'semantic',
+        chunkIndex: 0,
+        totalChunks: 3,
+        metadata: { source: 'platform-guidelines' },
+      });
+      // id/checksum are internals and should not leak to the agent context
+      expect(chunks[0]).not.toHaveProperty('id');
+      expect(chunks[0]).not.toHaveProperty('checksum');
+    });
+
+    it('returns a structured error when searchKnowledgeBase fails', async () => {
+      mockSearchKnowledgeBase.mockResolvedValue({
+        success: false,
+        chunks: [],
+        totalMatches: 0,
+        error: 'Plugin system not available',
+      });
+
+      const result = await executeKnowledgeTools('search_knowledge', {
+        query: 'yarn',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Plugin system not available');
+      expect(result.message).toContain('Plugin system not available');
+    });
+
+    it('catches thrown errors from the search pipeline', async () => {
+      mockSearchKnowledgeBase.mockRejectedValue(new Error('Qdrant unreachable'));
+
+      const result = await executeKnowledgeTools('search_knowledge', {
+        query: 'yarn',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Qdrant unreachable');
+    });
+
+    it('omits agentInstructions when no chunks match', async () => {
+      mockSearchKnowledgeBase.mockResolvedValue({
+        success: true,
+        chunks: [],
+        totalMatches: 0,
+      });
+
+      const result = await executeKnowledgeTools('search_knowledge', {
+        query: 'non-existent topic',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(0);
+      expect(result.agentInstructions).toBeUndefined();
+      expect(result.message).toContain('No matching documents found');
+    });
+  });
+});


### PR DESCRIPTION
## What

Two related fixes that together enable the `query` tool to cite
ingested documentation when backed by an OpenAI-compatible local LLM
(Ollama, vLLM, LiteLLM, or any other `CUSTOM_LLM_BASE_URL`).

Both issues are orthogonal, shipped on one branch as two clean
commits; happy to split into two PRs if preferred.

### Commit 1 — `fix(providers)`: wire `CUSTOM_LLM_API_KEY` / `OPENROUTER_API_KEY`

`createFromEnv()` in `src/core/ai-provider-factory.ts` short-circuits
to `NoOpAIProvider` when `PROVIDER_ENV_KEYS` has no entry for the
selected provider, even though `vercel-provider.ts` has both
`case 'custom':` and `case 'openrouter':` branches ready. Setting
`AI_PROVIDER=custom` (as the chart's `values.yaml` example suggests)
therefore surfaced as *"AI provider is not available. No API keys
configured."* even with `CUSTOM_LLM_API_KEY` and `CUSTOM_LLM_BASE_URL`
both set.

Added two map entries:

```
custom:     'CUSTOM_LLM_API_KEY',
openrouter: 'OPENROUTER_API_KEY',
```

### Commit 2 — `feat(query)`: add `search_knowledge` tool

The `query` agent's `localToolExecutor` handles capabilities,
resources, and mermaid — there is no branch for knowledge-base
search, and the tools passed to the LLM don't describe one. The
Web UI's "Knowledge" scope selector (`dot-ai-ui`) had no backend
hook: the LLM would either hallucinate or pick the
closest-named tool (`search_capabilities`) and return nothing
useful.

Adds `src/core/knowledge-tools.ts` with a read-only
`search_knowledge` tool that delegates to the existing exported
`searchKnowledgeBase` from `manage-knowledge.ts` — no duplicated
vector logic, no self-HTTP calls, no new RBAC surface. Write
operations (`ingest`, `deleteByUri`) remain on `manageKnowledge`
behind the existing `apply` verb gate.

Tool is wired into `query.ts` for both the normal and visualisation
tool lists. Also a short addition to `prompts/query-system.md` so
the agent picks the right tool for docs-style questions and
combines sources on hybrid queries (e.g. *"does any deployment
violate our yarn4 standards?"*).

## Why

End-users running a self-hosted stack (Kind / home-lab / air-gapped
clusters) want to point `dot-ai` at a local model and have the
"Query" tab surface content from GitKnowledgeSource-ingested
documentation. Today the UX is broken in both directions:

- Can't select a local-model provider (commit 1).
- Even if we could, the agent has no tool to search docs (commit 2).

A reviewer running a fresh deploy with

```yaml
dot-ai:
  ai:
    provider: custom
    model: qwen2.5:3b
    customEndpoint:
      enabled: true
      baseURL: http://host.docker.internal:11434/v1
```

gets a working query tool that cites ingested docs — no env shims,
no command overrides, no provider gymnastics.

## How it's tested

- `npm run test:unit` — **369 / 369 pass**, +18 new unit tests
  - 7 in `tests/unit/core/ai-provider-factory.test.ts`: happy path,
    missing key, openrouter happy/missing, anthropic + google_flash
    regression guards
  - 12 in `tests/unit/core/knowledge-tools.test.ts`: tool shape,
    unknown-tool dispatch, missing-query validation, limit clamping
    (default / max / min), `uriFilter` pass-through, chunk
    reshaping (internals dropped), structured error, thrown-error
    catch, empty-results messaging
- `npm run build` — clean.
- `npm run lint` — clean.

### Manual repro (end-to-end)

```bash
TOKEN="$(kubectl get secret dot-ai-secrets -n dot-ai \
  -o jsonpath='{.data.auth-token}' | base64 -d)"

curl -s -X POST http://dot-ai.127.0.0.1.nip.io/api/v1/tools/query \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"intent":"What does our yarn4 guide say about npmAuthToken and the @arkadium scope?"}' \
  --max-time 180 | jq '.data.result.result | {summary, toolsUsed}'
# Expected: toolsUsed includes "search_knowledge"; summary cites the
# ingested ADO markdown (e.g. contains "npmAuthToken").
```

## Notes for reviewers

- **Scope param named `uriFilter`**, not `sourceFilter`. The PRD
  that motivated this work proposed `sourceFilter: "dot-ai/..."` but
  the existing `searchKnowledgeBase` function exposes `uriFilter`
  which takes a full URI (Qdrant `match.value` = exact match).
  Kept the pass-through name to avoid inventing new filter semantics
  — happy to add a prefix/metadata-based `sourceFilter` in a follow-up
  if that's the direction you want.
- **System prompt change is additive** — three new bullets under a
  new "Source Selection" section. No existing guidance removed.
- **`package-lock.json` intentionally not touched** — it's stale
  against `package.json` on `main` (lock still says 1.15.2) but
  that's a separate cleanup.

Refs: PRD #194 (custom endpoints), PRD #291 (query tool), PRD #356
(knowledge base).

Signed-off-by: Alexander Konstantinov <claudeai-07@arkadium.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic search for organizational documentation, standards, and runbooks with clickable source citations.
  * Added support for custom LLM endpoints and OpenRouter as AI providers.
  * Smarter query routing: cluster-state queries use cluster tools; documentation queries use knowledge search; hybrid queries combine both.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->