### PR TITLE
fix: Update deployment image tag to valid nginx:latest in Git source

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag 'nginx:v999-nonexistent' is causing pods to fail during image pull. Changing to 'nginx:latest' provides a valid, stable image. Argo CD will automatically sync the change and reconcile the deployment.

**Risk Level:** low