### PR TITLE
fix: Update the image tag in the deployment manifest from non-existent version to valid nginx:latest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The current image tag doesn't exist in the Docker registry, preventing pod creation. Changing to nginx:latest provides a valid, stable image that will allow the pod to start successfully. Argo CD is configured with auto-sync enabled, so it will automatically deploy this change.

**Risk Level:** low