### PR TITLE
fix: Fix the invalid image tag in the deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The current image tag does not exist in any registry. Using a valid nginx image tag allows kubelet to successfully pull the image and start the pod. Argo CD will automatically detect and sync this change from the Git repository.

**Risk Level:** low