### PR TITLE
fix: Update the deployment image tag to valid 'nginx:latest' in Git source

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag v999-nonexistent does not exist in Docker Hub registry, causing the kubelet to fail pulling the image. Changing to 'nginx:latest' uses a valid, stable image tag. Argo CD will automatically sync this change due to the Application's automated sync policy (autoSync with prune and selfHeal enabled).

**Risk Level:** low