### PR TITLE
fix: Update the nginx image tag from v999-nonexistent to latest in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to a valid, published version (nginx:latest) resolves the ImagePullBackOff error. Argo CD with auto-sync enabled will automatically detect and apply this change to the cluster.

**Risk Level:** low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use valid container image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->