### PR TITLE
fix: Fix invalid image tag in deployment manifest stored in Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'v999-nonexistent' is invalid and prevents the container from being pulled. Changing to 'nginx:latest' (a valid, stable tag) resolves the ImagePullBackOff. Since this is a GitOps-managed resource, updating the source repository will trigger Argo CD to automatically reconcile and deploy the corrected manifest.

**Risk Level:** low