### PR TITLE
fix(helm): custom AI provider base URL now works through Helm chart (#474)

### DIFF
--- a/changelog.d/474-answer-validator-empty-select.bugfix.md
+++ b/changelog.d/474-answer-validator-empty-select.bugfix.md
@@ -1,0 +1,3 @@
+### Answer validator now accepts empty string when it's an explicit `select` option
+
+When the recommend tool generated a required `select` question whose `options` list explicitly included `""` (e.g., `["", "soft", "hard"]` to mean "no anti-affinity"), the answer validator rejected the empty string with a "required" error even though the question itself listed it as a valid choice. The validator now treats `""` as a valid answer for required `select` questions whenever it appears in the question's `options` array.

--- a/changelog.d/474-custom-provider-helm.bugfix.md
+++ b/changelog.d/474-custom-provider-helm.bugfix.md
@@ -1,0 +1,8 @@
+### Custom AI provider base URL now works through the Helm chart (#474)
+
+Two fixes so a custom OpenAI-compatible LLM endpoint can be configured end-to-end via Helm:
+
+- `AI_PROVIDER=custom` is now a first-class provider — `PROVIDER_ENV_KEYS` maps it to `CUSTOM_LLM_API_KEY`, so the MCP server no longer falls back to `NoOpProvider` when `ai.provider: custom` is set.
+- The Helm chart now omits the `AI_PROVIDER` env var when `ai.provider` is empty, restoring the auto-detect path that selects the `custom` provider whenever `customEndpoint.enabled: true` is configured.
+
+The default (`ai.provider: anthropic`) is unchanged. Users with a custom endpoint can pick whichever style they prefer: explicit (`ai.provider: custom`) or auto-detect (`ai.provider: ""`).

--- a/changelog.d/474-integration-draft-prs.misc.md
+++ b/changelog.d/474-integration-draft-prs.misc.md
@@ -1,0 +1,3 @@
+### Integration tests now create draft PRs to skip automated reviews
+
+The remediate tool's GitOps test path creates real PRs against `vfarcic/dot-ai` to verify the end-to-end flow. These transient PRs were briefly triggering CodeRabbit reviews. The PR creation in `handleGitCreatePr` now honors a `DOT_AI_GIT_CREATE_DRAFT_PRS=true` env var (set only on the integration test pod) to create those PRs as drafts, which CodeRabbit skips by configuration. Production behavior is unchanged.

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -43,8 +43,13 @@ spec:
         - name: SESSION_MODE
           value: "stateful"
         # AI Provider configuration
+        # Issue #474: Only emit AI_PROVIDER when explicitly set so that leaving
+        # ai.provider empty enables the auto-detect 'custom' branch in
+        # ai-provider-factory.ts when customEndpoint is configured.
+{{- if .Values.ai.provider }}
         - name: AI_PROVIDER
-          value: {{ .Values.ai.provider | default "anthropic" | quote }}
+          value: {{ .Values.ai.provider | quote }}
+{{- end }}
 {{- if .Values.ai.model }}
         - name: AI_MODEL
           value: {{ .Values.ai.model | quote }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -150,7 +150,7 @@ gateway:
 
 # AI Provider configuration
 ai:
-  provider: anthropic               # AI provider type (anthropic, anthropic_opus, anthropic_haiku, openai, google, google_flash, host, kimi, xai, amazon_bedrock)
+  provider: anthropic               # AI provider type (anthropic, anthropic_opus, anthropic_haiku, openai, google, google_flash, host, kimi, xai, amazon_bedrock, custom). Set to "" to auto-detect 'custom' from customEndpoint.
   model: ""                         # Optional: model override (e.g., "llama3.1:70b", "gpt-4o")
 
   # Custom endpoint configuration for self-hosted or alternative SaaS providers (PRD #194)
@@ -186,6 +186,18 @@ ai:
   #   customEndpoint:
   #     enabled: true
   #     baseURL: "http://vllm-service:8000/v1"  # /v1 suffix is REQUIRED
+  #
+  # Example 4: Generic OpenAI-compatible endpoint via the 'custom' provider (Issue #474)
+  # Use this when you want to be explicit that the endpoint is not OpenAI itself.
+  # ai:
+  #   provider: custom
+  #   model: "your-model-name"
+  #   customEndpoint:
+  #     enabled: true
+  #     baseURL: "https://your.custom.llm/v1"
+  # secrets:
+  #   customLlm:
+  #     apiKey: "your-api-key"
   #
   # Note: OpenAI-compatible endpoints (Ollama, vLLM, LocalAI) REQUIRE the /v1 suffix.
   # Without it, API calls will fail with 404 Not Found errors.

--- a/src/core/ai-provider-factory.ts
+++ b/src/core/ai-provider-factory.ts
@@ -8,10 +8,7 @@
  * Architecture supports future expansion to 19+ Vercel AI SDK providers
  */
 
-import {
-  AIProvider,
-  AIProviderConfig
-} from './ai-provider.interface';
+import { AIProvider, AIProviderConfig } from './ai-provider.interface';
 import { VercelProvider } from './providers/vercel-provider';
 import { HostProvider } from './providers/host-provider';
 import { NoOpAIProvider } from './providers/noop-provider';
@@ -32,6 +29,7 @@ const PROVIDER_ENV_KEYS: Record<string, string> = {
   kimi: 'MOONSHOT_API_KEY', // PRD #353: Moonshot AI Kimi K2.5
   alibaba: 'ALIBABA_API_KEY', // PRD #382: Alibaba Qwen 3.5 Plus
   xai: 'XAI_API_KEY',
+  custom: 'CUSTOM_LLM_API_KEY', // PRD #194 / Issue #474: Explicit opt-in to custom OpenAI-compatible endpoint
 };
 
 /**
@@ -39,7 +37,9 @@ const PROVIDER_ENV_KEYS: Record<string, string> = {
  * Single source of truth maintained in model-config.ts
  */
 type ImplementedProvider = keyof typeof CURRENT_MODELS;
-const IMPLEMENTED_PROVIDERS = Object.keys(CURRENT_MODELS) as ImplementedProvider[];
+const IMPLEMENTED_PROVIDERS = Object.keys(
+  CURRENT_MODELS
+) as ImplementedProvider[];
 
 /**
  * Factory for creating AI provider instances
@@ -71,7 +71,9 @@ export class AIProviderFactory {
 
     // Validate configuration
     if (!config.apiKey) {
-      throw new Error(AI_SERVICE_ERROR_TEMPLATES.API_KEY_REQUIRED(config.provider));
+      throw new Error(
+        AI_SERVICE_ERROR_TEMPLATES.API_KEY_REQUIRED(config.provider)
+      );
     }
 
     if (!config.provider) {
@@ -79,11 +81,13 @@ export class AIProviderFactory {
     }
 
     // Check if provider is implemented in Phase 1
-    if (!IMPLEMENTED_PROVIDERS.includes(config.provider as ImplementedProvider)) {
+    if (
+      !IMPLEMENTED_PROVIDERS.includes(config.provider as ImplementedProvider)
+    ) {
       throw new Error(
         `Provider '${config.provider}' is not yet implemented. ` +
-        `Phase 1 providers: ${IMPLEMENTED_PROVIDERS.join(', ')}. ` +
-        `Future phases will add support for additional Vercel AI SDK providers.`
+          `Phase 1 providers: ${IMPLEMENTED_PROVIDERS.join(', ')}. ` +
+          `Future phases will add support for additional Vercel AI SDK providers.`
       );
     }
 
@@ -110,8 +114,8 @@ export class AIProviderFactory {
       // Write to stderr for logging
       process.stderr.write(
         `WARNING: Invalid AI_PROVIDER: ${providerType}. ` +
-        `Must be one of: ${IMPLEMENTED_PROVIDERS.join(', ')}. ` +
-        `Falling back to NoOpProvider.\n`
+          `Must be one of: ${IMPLEMENTED_PROVIDERS.join(', ')}. ` +
+          `Falling back to NoOpProvider.\n`
       );
       return new NoOpAIProvider();
     }
@@ -134,21 +138,22 @@ export class AIProviderFactory {
       if (!apiKeyEnvVar) {
         process.stderr.write(
           `WARNING: No API key environment variable defined for provider: ${providerType}. ` +
-          `Falling back to NoOpProvider.\n`
+            `Falling back to NoOpProvider.\n`
         );
         return new NoOpAIProvider();
       }
 
       // Check primary env var, with fallback for Google providers (GOOGLE_API_KEY for backward compatibility)
-      let resolvedApiKey = process.env.CUSTOM_LLM_API_KEY || process.env[apiKeyEnvVar];
+      let resolvedApiKey =
+        process.env.CUSTOM_LLM_API_KEY || process.env[apiKeyEnvVar];
       if (!resolvedApiKey && providerType.startsWith('google')) {
         resolvedApiKey = process.env.GOOGLE_API_KEY; // Fallback for backward compatibility
       }
       if (!resolvedApiKey) {
         process.stderr.write(
           `INFO: ${apiKeyEnvVar} not configured. ` +
-          `AI features will be unavailable. ` +
-          `Tools that don't require AI (prompts, project-setup) will still work.\n`
+            `AI features will be unavailable. ` +
+            `Tools that don't require AI (prompts, project-setup) will still work.\n`
         );
         return new NoOpAIProvider();
       }

--- a/src/core/internal-tools.ts
+++ b/src/core/internal-tools.ts
@@ -61,9 +61,7 @@ export function validatePathWithinClones(inputPath: string): string {
 function repoUrlToDirectoryName(repoUrl: string): string {
   try {
     const url = new URL(repoUrl);
-    const repoPath = url.pathname
-      .replace(/^\//, '')
-      .replace(/\.git$/, '');
+    const repoPath = url.pathname.replace(/^\//, '').replace(/\.git$/, '');
     return sanitizeIntentForLabel(repoPath);
   } catch {
     return sanitizeIntentForLabel(repoUrl.slice(0, 63));
@@ -184,7 +182,7 @@ function handleFsList(args: Record<string, unknown>): unknown {
   }
 
   const entries = fs.readdirSync(resolved, { withFileTypes: true });
-  return entries.map((entry) => ({
+  return entries.map(entry => ({
     name: entry.name,
     type: entry.isDirectory() ? 'directory' : 'file',
   }));
@@ -249,8 +247,21 @@ export interface GitCreatePrInput {
 }
 
 export type GitCreatePrResult =
-  | { success: true; prUrl: string; prNumber: number; branch: string; baseBranch: string; filesChanged: string[] }
-  | { success: true; branch: string; baseBranch: string; filesChanged: string[]; error: string }
+  | {
+      success: true;
+      prUrl: string;
+      prNumber: number;
+      branch: string;
+      baseBranch: string;
+      filesChanged: string[];
+    }
+  | {
+      success: true;
+      branch: string;
+      baseBranch: string;
+      filesChanged: string[];
+      error: string;
+    }
   | { success: false; error: string };
 
 async function handleGitCreatePr(
@@ -267,7 +278,10 @@ async function handleGitCreatePr(
     return { success: false, error: 'repoPath is required' };
   }
   if (!files || !Array.isArray(files) || files.length === 0) {
-    return { success: false, error: 'files array is required and must not be empty' };
+    return {
+      success: false,
+      error: 'files array is required and must not be empty',
+    };
   }
   if (!title) {
     return { success: false, error: 'title is required' };
@@ -300,7 +314,7 @@ async function handleGitCreatePr(
 
   try {
     const git = simpleGit(resolvedRepoPath);
-    
+
     await git.checkout(baseBranch);
 
     const pushResult = await pushRepo(resolvedRepoPath, files, title, {
@@ -317,14 +331,17 @@ async function handleGitCreatePr(
     }
     const remoteUrl = scrubCredentials(origin.refs.fetch);
 
-    const repoMatch = remoteUrl.match(/github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/);
+    const repoMatch = remoteUrl.match(
+      /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/
+    );
     if (!repoMatch) {
       return {
         success: true,
         branch: branchName,
         baseBranch,
         filesChanged: pushResult.filesAdded,
-        error: 'Automatic PR creation is only supported for GitHub repositories. Changes were pushed to the branch — create a PR/MR manually.',
+        error:
+          'Automatic PR creation is only supported for GitHub repositories. Changes were pushed to the branch — create a PR/MR manually.',
       };
     }
     const ownerRepo = repoMatch[1];
@@ -345,6 +362,12 @@ async function handleGitCreatePr(
           body,
           head: branchName,
           base: baseBranch,
+          // Test-only switch: integration tests set this so PRs they create
+          // don't trigger CodeRabbit (which has drafts: false in .coderabbit.yaml).
+          // Production never sets this env var.
+          ...(process.env.DOT_AI_GIT_CREATE_DRAFT_PRS === 'true' && {
+            draft: true,
+          }),
         }),
         signal: AbortSignal.timeout(30000),
       }
@@ -388,7 +411,7 @@ export function createInternalToolExecutor(sessionId: string): ToolExecutor {
     string,
     (args: Record<string, unknown>) => unknown | Promise<unknown>
   > = {
-    git_clone: (args) => handleGitClone(args, sessionId),
+    git_clone: args => handleGitClone(args, sessionId),
     fs_list: handleFsList,
     fs_read: handleFsRead,
     git_create_pr: handleGitCreatePr,
@@ -416,21 +439,24 @@ export function createInternalToolExecutor(sessionId: string): ToolExecutor {
 export function cleanupOldClones(maxAgeMs: number = DEFAULT_TTL_MS): void {
   const clonesDir = getClonesDir();
 
-  fs.promises.access(clonesDir).then(async () => {
-    const now = Date.now();
-    const entries = await fs.promises.readdir(clonesDir);
-    for (const entry of entries) {
-      const entryPath = path.join(clonesDir, entry);
-      try {
-        const stat = await fs.promises.stat(entryPath);
-        if (stat.isDirectory() && now - stat.mtimeMs > maxAgeMs) {
-          await fs.promises.rm(entryPath, { recursive: true, force: true });
+  fs.promises
+    .access(clonesDir)
+    .then(async () => {
+      const now = Date.now();
+      const entries = await fs.promises.readdir(clonesDir);
+      for (const entry of entries) {
+        const entryPath = path.join(clonesDir, entry);
+        try {
+          const stat = await fs.promises.stat(entryPath);
+          if (stat.isDirectory() && now - stat.mtimeMs > maxAgeMs) {
+            await fs.promises.rm(entryPath, { recursive: true, force: true });
+          }
+        } catch {
+          // Ignore errors during cleanup (e.g., concurrent deletion)
         }
-      } catch {
-        // Ignore errors during cleanup (e.g., concurrent deletion)
       }
-    }
-  }).catch(() => {
-    // Directory doesn't exist yet, nothing to clean
-  });
+    })
+    .catch(() => {
+      // Directory doesn't exist yet, nothing to clean
+    });
 }

--- a/src/tools/answer-question.ts
+++ b/src/tools/answer-question.ts
@@ -115,11 +115,25 @@ export const ANSWERQUESTION_TOOL_INPUT_SCHEMA = {
 /**
  * Validate answer against question schema
  */
-function validateAnswer(answer: unknown, question: Question): string | null {
-  // Check required validation
+export function validateAnswer(
+  answer: unknown,
+  question: Question
+): string | null {
+  // Check required validation.
+  // Issue #474: For 'select' questions, empty string is a valid answer when it
+  // is explicitly listed in `options` (e.g., options=["", "soft", "hard"] where
+  // "" represents the "none/disabled" choice). Skip the empty-string rejection
+  // in that case so the question's own option list is the source of truth.
+  const emptyAnswer = answer === undefined || answer === null || answer === '';
+  const isExplicitEmptySelectOption =
+    question.type === 'select' &&
+    answer === '' &&
+    Array.isArray(question.options) &&
+    question.options.includes('');
   if (
     question.validation?.required &&
-    (answer === undefined || answer === null || answer === '')
+    emptyAnswer &&
+    !isExplicitEmptySelectOption
   ) {
     return question.validation.message || `${question.question} is required`;
   }

--- a/tests/integration/infrastructure/run-integration-tests.sh
+++ b/tests/integration/infrastructure/run-integration-tests.sh
@@ -551,7 +551,7 @@ helm upgrade --install dot-ai ./charts \
     --set plugins.agentic-tools.image.pullPolicy=Never \
     "${HELM_MCP_ARGS[@]}" \
     --set rbac.enforcement.enabled="${RBAC_ENABLED}" \
-    --set-json "extraEnv=[{\"name\":\"QDRANT_CAPABILITIES_COLLECTION\",\"value\":\"capabilities-policies\"},{\"name\":\"DEBUG_DOT_AI\",\"value\":\"true\"},{\"name\":\"DOT_AI_TELEMETRY\",\"value\":\"${DOT_AI_TELEMETRY:-false}\"},{\"name\":\"CI\",\"value\":\"true\"},{\"name\":\"DOT_AI_USER_PROMPTS_REPO\",\"value\":\"${DOT_AI_USER_PROMPTS_REPO}\"},{\"name\":\"DOT_AI_USER_PROMPTS_PATH\",\"value\":\"user-prompts\"},{\"name\":\"DOT_AI_GIT_TOKEN\",\"value\":\"${DOT_AI_GIT_TOKEN:-}\"},{\"name\":\"MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL\",\"value\":\"true\"}]" \
+    --set-json "extraEnv=[{\"name\":\"QDRANT_CAPABILITIES_COLLECTION\",\"value\":\"capabilities-policies\"},{\"name\":\"DEBUG_DOT_AI\",\"value\":\"true\"},{\"name\":\"DOT_AI_TELEMETRY\",\"value\":\"${DOT_AI_TELEMETRY:-false}\"},{\"name\":\"CI\",\"value\":\"true\"},{\"name\":\"DOT_AI_USER_PROMPTS_REPO\",\"value\":\"${DOT_AI_USER_PROMPTS_REPO}\"},{\"name\":\"DOT_AI_USER_PROMPTS_PATH\",\"value\":\"user-prompts\"},{\"name\":\"DOT_AI_GIT_TOKEN\",\"value\":\"${DOT_AI_GIT_TOKEN:-}\"},{\"name\":\"DOT_AI_GIT_CREATE_DRAFT_PRS\",\"value\":\"true\"},{\"name\":\"MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL\",\"value\":\"true\"}]" \
     --wait --timeout=300s || {
     log_error "Failed to deploy dot-ai via Helm"
     kubectl get pods -n dot-ai

--- a/tests/integration/tools/remediate.test.ts
+++ b/tests/integration/tools/remediate.test.ts
@@ -22,7 +22,7 @@ function openSSE(path: string): {
 } {
   const chunks: string[] = [];
   let resolveResponse: (res: http.IncomingMessage) => void;
-  const response = new Promise<http.IncomingMessage>((resolve) => {
+  const response = new Promise<http.IncomingMessage>(resolve => {
     resolveResponse = resolve;
   });
 
@@ -33,7 +33,7 @@ function openSSE(path: string): {
     headers['Authorization'] = `Bearer ${authToken}`;
   }
 
-  const req = http.get(url, { headers }, (res) => {
+  const req = http.get(url, { headers }, res => {
     resolveResponse(res);
     res.setEncoding('utf8');
     res.on('data', (chunk: string) => {
@@ -307,9 +307,8 @@ EOF`);
       expect(sessionResponse).toMatchObject(expectedSessionResponse);
 
       // SESSION LIST: Test GET /api/v1/sessions (PRD #425)
-      const listResponse = await integrationTest.httpClient.get(
-        '/api/v1/sessions'
-      );
+      const listResponse =
+        await integrationTest.httpClient.get('/api/v1/sessions');
 
       expect(listResponse).toMatchObject({
         success: true,
@@ -327,8 +326,10 @@ EOF`);
       });
 
       // Verify our session appears in the list
-      const sessions = listResponse.data.sessions as Array<Record<string, unknown>>;
-      const ourSession = sessions.find((s) => s.sessionId === sessionId);
+      const sessions = listResponse.data.sessions as Array<
+        Record<string, unknown>
+      >;
+      const ourSession = sessions.find(s => s.sessionId === sessionId);
       expect(ourSession).toBeDefined();
       expect(ourSession).toMatchObject({
         sessionId: sessionId,
@@ -349,11 +350,13 @@ EOF`);
         '/api/v1/sessions?status=analysis_complete'
       );
       expect(filteredResponse.success).toBe(true);
-      const filteredSessions = filteredResponse.data.sessions as Array<Record<string, unknown>>;
+      const filteredSessions = filteredResponse.data.sessions as Array<
+        Record<string, unknown>
+      >;
       for (const s of filteredSessions) {
         expect(s.status).toBe('analysis_complete');
       }
-      expect(filteredSessions.some((s) => s.sessionId === sessionId)).toBe(true);
+      expect(filteredSessions.some(s => s.sessionId === sessionId)).toBe(true);
 
       // Verify pagination works
       const paginatedResponse = await integrationTest.httpClient.get(
@@ -503,7 +506,7 @@ EOF`);
       // Verify all SSE data lines are valid JSON with expected shape
       const dataLines = allSSEData
         .split('\n')
-        .filter((line) => line.startsWith('data: '));
+        .filter(line => line.startsWith('data: '));
       expect(dataLines.length).toBeGreaterThanOrEqual(2); // At least created + updated
 
       for (const line of dataLines) {
@@ -518,7 +521,8 @@ EOF`);
       }
 
       // Verify server is still healthy after SSE disconnect
-      const healthResponse = await integrationTest.httpClient.get('/api/v1/sessions');
+      const healthResponse =
+        await integrationTest.httpClient.get('/api/v1/sessions');
       expect(healthResponse.success).toBe(true);
     }, 1200000); // 20 minute timeout for AI investigation + execution + validation (accommodates slower AI models like Gemini)
   });
@@ -1352,9 +1356,13 @@ EOF`);
             title: string;
             body: string;
             state: string;
+            draft: boolean;
             head: { ref: string };
           };
           expect(prData.state).toBe('open');
+          // Integration tests set DOT_AI_GIT_CREATE_DRAFT_PRS=true so PRs
+          // created during testing don't trigger CodeRabbit reviews.
+          expect(prData.draft).toBe(true);
           expect(prData.title).toContain('fix:');
           expect(prData.body).toContain('Remediation');
           expect(prData.head.ref).toBe(prBranch);

--- a/tests/unit/core/providers/custom-headers-base-url.test.ts
+++ b/tests/unit/core/providers/custom-headers-base-url.test.ts
@@ -305,6 +305,50 @@ describe('PRD #443: Custom Headers and Base URL Support', () => {
     });
   });
 
+  describe("Issue #474: Explicit AI_PROVIDER='custom'", () => {
+    it('should create VercelProvider (not NoOp) when AI_PROVIDER=custom + CUSTOM_LLM_API_KEY + CUSTOM_LLM_BASE_URL are set', () => {
+      process.env.AI_PROVIDER = 'custom';
+      process.env.CUSTOM_LLM_API_KEY = 'test-key';
+      process.env.CUSTOM_LLM_BASE_URL = 'https://my.custom.llm/v1';
+
+      AIProviderFactory.createFromEnv();
+
+      expect(mockCreateOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'test-key',
+          baseURL: 'https://my.custom.llm/v1',
+        })
+      );
+    });
+
+    it('should resolve API key from CUSTOM_LLM_API_KEY for AI_PROVIDER=custom', () => {
+      process.env.AI_PROVIDER = 'custom';
+      process.env.CUSTOM_LLM_API_KEY = 'custom-only-key';
+      process.env.CUSTOM_LLM_BASE_URL = 'https://my.custom.llm/v1';
+      delete process.env.OPENAI_API_KEY;
+
+      AIProviderFactory.createFromEnv();
+
+      const callArgs = mockCreateOpenAI.mock.calls[0]?.[0];
+      expect(callArgs.apiKey).toBe('custom-only-key');
+    });
+
+    it('should pass custom headers when AI_PROVIDER=custom', () => {
+      process.env.AI_PROVIDER = 'custom';
+      process.env.CUSTOM_LLM_API_KEY = 'test-key';
+      process.env.CUSTOM_LLM_BASE_URL = 'https://my.custom.llm/v1';
+      process.env.CUSTOM_LLM_HEADERS = '{"x-custom": "value"}';
+
+      AIProviderFactory.createFromEnv();
+
+      expect(mockCreateOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: { 'x-custom': 'value' },
+        })
+      );
+    });
+  });
+
   describe('Anthropic Bearer auth (authToken) for corporate proxies', () => {
     it('should use authToken when Authorization header is in custom headers', () => {
       process.env.ANTHROPIC_API_KEY = 'test-key';

--- a/tests/unit/helm/ai-provider.test.ts
+++ b/tests/unit/helm/ai-provider.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit Test: AI_PROVIDER Helm Chart Conditional (Issue #474)
+ *
+ * Verifies the chart conditionally emits the AI_PROVIDER env var so the
+ * MCP server's auto-detect 'custom' branch in ai-provider-factory.ts is
+ * reachable when ai.provider is empty, and the explicit 'custom' value
+ * is forwarded when set.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { execSync } from 'child_process';
+import * as yaml from 'js-yaml';
+
+interface DeploymentResource {
+  apiVersion: string;
+  kind: 'Deployment';
+  metadata: { name: string };
+  spec: {
+    template: {
+      spec: {
+        containers: Array<{
+          name: string;
+          env?: Array<{ name: string; value?: string }>;
+        }>;
+      };
+    };
+  };
+}
+
+describe.concurrent(
+  'AI_PROVIDER Conditional Helm Rendering (Issue #474)',
+  () => {
+    const chartPath = './charts';
+
+    function helmTemplate(setArgs: string): string {
+      return execSync(`helm template test-ai ${chartPath} ${setArgs}`, {
+        encoding: 'utf-8',
+      });
+    }
+
+    function parseYamlDocs(output: string): unknown[] {
+      return output
+        .split('---')
+        .map(doc => doc.trim())
+        .filter(doc => doc.length > 0)
+        .map(doc => yaml.load(doc));
+    }
+
+    function getMcpServerEnv(
+      deployment: DeploymentResource,
+      name: string
+    ): { name: string; value?: string } | undefined {
+      const container = deployment.spec.template.spec.containers.find(
+        c => c.name === 'mcp-server'
+      );
+      return container?.env?.find(e => e.name === name);
+    }
+
+    function getDeployment(output: string): DeploymentResource {
+      const docs = parseYamlDocs(output);
+      const deployment = docs.find(
+        d =>
+          typeof d === 'object' &&
+          d !== null &&
+          'kind' in d &&
+          d.kind === 'Deployment' &&
+          'metadata' in d &&
+          typeof (d as any).metadata?.name === 'string' &&
+          (d as any).metadata.name === 'test-ai-dot-ai'
+      ) as DeploymentResource | undefined;
+      expect(deployment).toBeDefined();
+      return deployment!;
+    }
+
+    test('omits AI_PROVIDER env var when ai.provider is empty (auto-detect path)', () => {
+      const output = helmTemplate('--set ai.provider=""');
+      const deployment = getDeployment(output);
+
+      const aiProvider = getMcpServerEnv(deployment, 'AI_PROVIDER');
+      expect(aiProvider).toBeUndefined();
+    });
+
+    test('emits AI_PROVIDER=custom when ai.provider=custom', () => {
+      const output = helmTemplate(
+        '--set ai.provider=custom --set ai.customEndpoint.enabled=true --set ai.customEndpoint.baseURL=https://my.custom.llm/v1'
+      );
+      const deployment = getDeployment(output);
+
+      const aiProvider = getMcpServerEnv(deployment, 'AI_PROVIDER');
+      expect(aiProvider?.value).toBe('custom');
+    });
+
+    test('emits AI_PROVIDER=anthropic by default (no breaking change)', () => {
+      const output = helmTemplate('');
+      const deployment = getDeployment(output);
+
+      const aiProvider = getMcpServerEnv(deployment, 'AI_PROVIDER');
+      expect(aiProvider?.value).toBe('anthropic');
+    });
+  }
+);

--- a/tests/unit/tools/answer-question.test.ts
+++ b/tests/unit/tools/answer-question.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { validateAnswer } from '../../../src/tools/answer-question';
+import type { Question } from '../../../src/core/schema';
+
+describe('validateAnswer', () => {
+  describe('Issue #474: select questions with explicit empty-string option', () => {
+    it("accepts answer='' when type='select', required=true, and '' is in options", () => {
+      const question: Question = {
+        id: 'pod-anti-affinity',
+        question: 'Pod anti-affinity strategy for Prometheus replicas',
+        type: 'select',
+        options: ['', 'soft', 'hard'],
+        validation: { required: true },
+      } as Question;
+
+      expect(validateAnswer('', question)).toBeNull();
+    });
+
+    it("rejects answer='' when type='select', required=true, but '' is NOT in options", () => {
+      const question: Question = {
+        id: 'service-type',
+        question: 'What type of Kubernetes Service should Prometheus use?',
+        type: 'select',
+        options: ['ClusterIP', 'NodePort', 'LoadBalancer'],
+        validation: { required: true },
+      } as Question;
+
+      expect(validateAnswer('', question)).toContain('required');
+    });
+
+    it("rejects answer='' for required text questions (empty option exception only applies to select)", () => {
+      const question: Question = {
+        id: 'name',
+        question: 'What is the name?',
+        type: 'text',
+        validation: { required: true },
+      } as Question;
+
+      expect(validateAnswer('', question)).toContain('required');
+    });
+
+    it('still validates that select answer is in options list', () => {
+      const question: Question = {
+        id: 'pod-anti-affinity',
+        question: 'Pod anti-affinity strategy',
+        type: 'select',
+        options: ['', 'soft', 'hard'],
+        validation: { required: true },
+      } as Question;
+
+      expect(validateAnswer('invalid-choice', question)).toContain(
+        'must be one of'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

**What does this PR do?**

Closes #474. Three bug fixes that together let users configure a custom OpenAI-compatible LLM endpoint end-to-end via the Helm chart:

1. `AI_PROVIDER=custom` is now a first-class provider — `PROVIDER_ENV_KEYS` maps it to `CUSTOM_LLM_API_KEY`, so the MCP server no longer falls back to `NoOpProvider` when `ai.provider: custom` is set.
2. The Helm chart omits the `AI_PROVIDER` env var when `ai.provider` is empty, restoring the PRD #443 auto-detect path that selects the `custom` provider whenever `customEndpoint.enabled: true` is configured.
3. The answer-question validator now accepts `""` as a valid answer for required `select` questions when `""` is explicitly listed in `options` (e.g., `["", "soft", "hard"]` for pod anti-affinity meaning "none"). Surfaced by a flaky integration test that became reproducible once analyzed against debug-AI prompt logs.

**Why is this change needed?**

Reporter found that setting `ai.provider: openai` + `customEndpoint.enabled: true` works (createOpenAI accepts `baseURL`), but `ai.provider: custom` falls back to NoOpProvider, and there is no way to leave `AI_PROVIDER` unset through Helm. Both paths need to work for users who want explicit custom-provider semantics. The validator bug was an unrelated issue surfaced by re-running integration tests on the cleaned-up branch.

## Related Issues

Closes #474

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Test updates (adding or updating tests)
- [x] 🔧 Configuration changes (Helm chart)

## Testing Checklist

- [x] Tests added or updated
- [x] All existing tests pass locally
- [x] Manual testing performed (helm template renders verified)
- [x] Test coverage maintained or improved

**Test commands run:**
\`\`\`bash
npm run test:unit          # 358 passed (4 new for validator, 3 new for AI_PROVIDER=custom)
npm run test:integration   # 218 passed / 2 skipped / 0 failed (full suite)
helm template test charts/ --set ai.provider=custom --set ai.customEndpoint.enabled=true ...
\`\`\`

**Test results:** All unit and integration tests pass; previously-failing \`Helm Chart Discovery > should complete Helm workflow\` test now passes after validator fix.

## Documentation Checklist

- [x] Documentation updated (charts/values.yaml comment + Example 4 for \`provider: custom\`)
- [x] Code comments added for non-obvious logic (validator, deployment.yaml)

## Security Checklist

- [x] No secrets or credentials committed
- [x] Authentication/authorization logic reviewed (no auth code touched)

## Breaking Changes

- [x] No

Default \`ai.provider: anthropic\` is unchanged. Users who already set \`ai.provider: openai\` + \`customEndpoint\` continue to work.

## Additional Context

**Reviewer Notes:**
- \`src/core/ai-provider-factory.ts\` diff is large because Prettier reformatted the file; the only behavioral change is one line adding \`custom: 'CUSTOM_LLM_API_KEY'\` to \`PROVIDER_ENV_KEYS\`.
- \`validateAnswer\` was changed from a private function to an exported one so it could be unit-tested directly.

**Follow-up Work:** None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Answer validator now properly allows empty string selection for required select questions when explicitly listed as an option
  * Custom AI provider configuration via Helm charts now works end-to-end with proper environment variable mapping

* **Documentation**
  * Helm chart documentation updated with custom provider configuration examples and setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->