### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from non-existent 'nginx:v999-nonexistent' to valid 'nginx:latest' allows kubelet to pull the image. Argo CD's automated sync will detect the change and redeploy with the corrected image. This resolves the ImagePullBackOff error.

**Risk Level:** low