### PR TITLE
fix: Update the deployment manifest to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from the non-existent 'v999-nonexistent' to 'latest' resolves the ImagePullBackOff error by allowing the kubelet to successfully pull the image from Docker Hub. Argo CD's automated sync will reconcile the change automatically.

**Risk Level:** low