### PR TITLE
fix: Update image tag in deployment.yaml from 'nginx:v999-nonexistent' to a valid stable tag 'nginx:1.27'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:1.27
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image 'nginx:v999-nonexistent' does not exist in Docker Hub. Replacing with a valid published tag 'nginx:1.27' resolves the ImagePullBackOff. Since Argo CD has automated sync with selfHeal enabled, modifying the cluster directly would be reverted - the fix must come through Git.

**Risk Level:** low