### PR TITLE
fix: Update the image tag in the Git source deployment manifest from 'nginx:v999-nonexistent' to a valid tag 'nginx:1.27'. Argo CD will automatically detect the change and sync it to the cluster.

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:1.27
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The deployment is GitOps-managed by Argo CD with automated sync and self-heal enabled. Direct kubectl patches would be reverted by Argo CD. Fixing the image in Git is the proper way to resolve the ImagePullBackOff and ensure the change persists.

**Risk Level:** low