### PR TITLE
fix: Update the Deployment manifest in Git to replace the non-existent nginx image tag with a valid tag.

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Because the Deployment is managed by Argo CD with automated sync/self-heal, changing the live Deployment directly would be reverted. Updating the Git source allows Argo CD to apply the corrected image consistently.

**Risk Level:** low