### PR TITLE
fix: Update the GitOps deployment manifest to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:stable-alpine
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Because Argo CD has automated sync and self-heal enabled, changing the Git source is the correct durable fix. Direct kubectl edits would be reverted by Argo CD.

**Risk Level:** low