### PR TITLE
fix: Update the deployment manifest in the Git repository to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image to a valid tag resolves the ImagePullBackOff. Because the ArgoCD application has selfHeal enabled, updating the source manifest is the only durable fix. ArgoCD will automatically sync the corrected manifest.

**Risk Level:** low