### PR TITLE
fix: Fix the image tag in the deployment manifest from nginx:v999-nonexistent to nginx:latest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Using a valid, publicly available nginx tag resolves the ImagePullBackOff. Argo CD automated self-heal will apply the change once it is committed to the repository.

**Risk Level:** low