### PR TITLE
fix: Update image tag from 'nginx:v999-nonexistent' to 'nginx:1.25.0' in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:1.25.0
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to a valid nginx image tag resolves the ImagePullBackOff. Argo CD with self-heal enabled will automatically sync the change within seconds.

**Risk Level:** low