### PR TITLE
fix: Fix the image tag in the deployment manifest within the Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image to a valid version (nginx:latest) resolves the ImagePullBackOff issue. Since the resource is managed by Argo CD, the fix must be applied to the Git source of truth.

**Risk Level:** low