### PR TITLE
fix: Update deployment.yaml to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag is the root cause of the ImagePullBackOff error. Changing to 'nginx:latest' (a valid, existing image) allows the pod to pull the image successfully. ArgoCD will automatically sync this change due to the automated sync policy.

**Risk Level:** low