### PR TITLE
fix: Fix the invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image from 'nginx:v999-nonexistent' to 'nginx:latest' resolves the ImagePullBackOff error. The nginx:latest image is publicly available and stable. Argo CD will automatically detect and sync this change due to the automated sync policy configured.

**Risk Level:** low