### PR TITLE
chore(renovate): widen Dockerfile exclusion to cover all paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
       "description": "Keep using :latest tags in docker-compose-dot-ai.yaml"
     },
     {
-      "matchFileNames": ["Dockerfile", "Dockerfile-qdrant"],
+      "matchFileNames": ["**/Dockerfile", "**/Dockerfile-*"],
       "pinDigests": false,
       "description": "Disable digest pinning for multi-architecture base images. SHA256 digests pin to a single architecture and break ARM/ARM64 support."
     },


### PR DESCRIPTION
## Summary

- The `pinDigests: false` rule for base-image Dockerfiles used an exact `matchFileNames` list (`"Dockerfile"`, `"Dockerfile-qdrant"`) that only covered the two Dockerfiles at the repo root.
- The three Dockerfiles in subdirectories (`dex-theme/`, `mock-server/`, `packages/agentic-tools/`) were unaffected, so Renovate kept adding or updating SHA digest pins on them — which breaks ARM64 / multi-arch builds (KinD on Mac, etc.).
- Switches to `**/Dockerfile` + `**/Dockerfile-*` globs so every Dockerfile in the repo gets the same treatment.

Trigger: Renovate PR #499 attempted to add a digest pin to `dex-theme/Dockerfile`. Closed that one; opened this PR so the same kind of slip can't recur for the other Dockerfiles.

## Test plan

- [ ] Renovate Dependency Dashboard (#42) re-checked — no new digest-pin-only PRs queued for `dex-theme/`, `mock-server/`, or `packages/agentic-tools/` after this merges.
- [ ] Existing Renovate PRs that update digests on those files (#505, #506) auto-close on Renovate's next run, since `pinDigests: false` should invalidate the update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to broaden Dockerfile dependency management across the project, expanding file pattern matching for improved consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-ai/pull/563)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->