### PR TITLE
fix: Fix the container image tag in the deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to a valid image tag allows the image to be pulled successfully from the container registry. The pods will then start properly and the ImagePullBackOff condition will be resolved. Argo CD will automatically sync this change and reconcile the deployment.

**Risk Level:** low