### PR TITLE
fix: Update the invalid image tag in the deployment manifest to use a valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Replacing the non-existent image tag with a valid 'nginx:latest' tag will allow the kubelet to successfully pull the image and the pod to start. Argo CD will automatically sync this change to the cluster.

**Risk Level:** low