### PR TITLE
fix: Fix the container image tag from 'nginx:v999-nonexistent' to 'nginx:latest' in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag is the root cause of ImagePullBackOff. Using 'nginx:latest' provides a valid, publicly available image that can be pulled successfully. Once the Git source is updated, Argo CD's auto-sync policy will detect the change and redeploy with the corrected image.

**Risk Level:** low