### PR TITLE
fix: Update deployment.yaml in Git repository to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag to 'nginx:latest' provides a valid, existing image that can be pulled from Docker registry. Argo CD's automated sync policy will immediately detect this change and apply it, allowing pods to start successfully.

**Risk Level:** low