### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from the non-existent 'nginx:v999-nonexistent' to 'nginx:latest' (a valid, stable image) allows the kubelet to successfully pull the container image. Argo CD's automated sync will detect the change and apply it to the cluster.

**Risk Level:** low