### PR TITLE
fix: Update the container image tag in the deployment manifest to use valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing from non-existent image tag to 'nginx:latest' allows the kubelet to successfully pull the image. Argo CD's automated sync will detect this change in Git and resync the deployment, causing new pods to be created with the correct image.

**Risk Level:** low