### PR TITLE
fix: Fix image tag in deployment manifest to use valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The non-existent image tag 'nginx:v999-nonexistent' must be replaced with a valid existing tag. Using 'nginx:latest' provides a valid, stable base image. Argo CD will automatically sync the change when the Git repository is updated.

**Risk Level:** low