### PR TITLE
fix: Fix image tag in deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to a valid image tag (nginx:latest) allows kubelet to successfully pull the image and start the pod. Argo CD will automatically sync this change due to the configured auto-sync and self-heal policies.

**Risk Level:** low