### PR TITLE
fix: Fix invalid image tag in deployment manifest in Git source

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag to 'nginx:latest' (a valid, stable nginx image) resolves the ImagePullBackOff error. Argo CD will automatically detect the change in Git, sync the updated manifest, and trigger pod recreation with the correct image.

**Risk Level:** low