### PR TITLE
fix: Fix invalid image tag in deployment manifest in Git source

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from a non-existent 'v999-nonexistent' to 'latest' (which exists in the Docker Hub registry) will allow the kubelet to successfully pull the image. Argo CD is configured with automated sync, so it will detect the Git change and reconcile the deployment automatically.

**Risk Level:** low