### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'nginx:v999-nonexistent' is clearly a broken placeholder tag that does not exist in the registry. Changing it to 'nginx:latest' uses a stable, commonly available nginx image that will successfully pull. Since the Application has automated sync enabled, Argo CD will automatically reconcile the deployment after this change.

**Risk Level:** low