### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag to 'nginx:latest' (an existing, valid tag) allows kubelet to successfully pull the image and start the container. Argo CD's automated sync and self-heal will automatically apply this change.

**Risk Level:** low