### PR TITLE
fix: Fix the image tag in deployment.yaml from nginx:v999-nonexistent to nginx:latest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The current image tag does not exist in Docker registry. Changing to nginx:latest uses a valid, officially maintained image that can be pulled successfully. Argo CD will automatically detect and sync this change due to the enabled automated sync policy.

**Risk Level:** low