### PR TITLE
fix: Fix image tag in deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag is the root cause of the ImagePullBackOff error. Updating to a valid, stable image tag (nginx:latest) will allow the container to be pulled and started successfully. Argo CD will automatically sync this change.

**Risk Level:** low