### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image to 'nginx:latest' provides a valid, pullable image. Since Argo CD has automated sync enabled, it will automatically detect this change and reconcile the deployment, allowing the pod to successfully pull the image and transition to Running state.

**Risk Level:** low