### PR TITLE
fix: Update the deployment manifest to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The current image tag does not exist in any registry. Using 'nginx:latest' provides a valid, stable, and commonly-used nginx image that will allow the pods to pull successfully and start running.

**Risk Level:** low