### PR TITLE
fix: Fix container image tag in deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag is the root cause of the ImagePullBackOff error. Changing to a valid, stable nginx image tag allows the pod to pull and start successfully. Since Argo CD has automated sync enabled, the change will be automatically deployed.

**Risk Level:** low