### PR TITLE
fix: Update deployment.yaml image tag from invalid 'nginx:v999-nonexistent' to valid 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to a valid, stable image tag resolves the ImagePullBackOff error. nginx:latest is a well-maintained public image. Argo CD will automatically sync this change due to the automated sync policy configured on the gitops-test-argocd Application.

**Risk Level:** low