### PR TITLE
fix: Update deployment manifest to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from 'nginx:v999-nonexistent' to 'nginx:latest' (or another valid tag) resolves the ImagePullBackOff error. The Docker registry contains valid nginx images that kubelet can pull. Argo CD's automated self-healing will detect the repository change and sync it to the cluster, causing pods to be recreated with the valid image.

**Risk Level:** low