### PR TITLE
fix: Fix image tag in deployment.yaml to use valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' (a valid, publicly available image) allows the pod to successfully pull the image and start. Argo CD will detect the Git change and automatically sync it due to the automated sync policy configured.

**Risk Level:** low