### PR TITLE
fix: Fix the invalid image tag in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Replacing the non-existent image tag 'v999-nonexistent' with 'latest' (or another valid tag) allows kubelet to successfully pull the image and start the container. Since the deployment is managed by Argo CD with automated sync enabled, the change in Git will be automatically applied to the cluster.

**Risk Level:** low