### PR TITLE
feat: per-request user prompts repository override (#581)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ gke_gcloud_auth_plugin_cache
 # Crush
 .crush/
 
+# Agent coordination artifacts (dot-agent-deck worker tasks and reports)
+.dot-agent-deck/
+
 # Local testing scripts
 start-http-server.sh
 

--- a/changelog.d/581.feature.md
+++ b/changelog.d/581.feature.md
@@ -1,0 +1,9 @@
+## Per-Request User Prompts Repository Override
+
+The three prompts REST endpoints now accept an optional `repo` parameter that overrides `DOT_AI_USER_PROMPTS_REPO` for a single request, letting CLI consumers compose skills from multiple repositories without standing up multiple servers or aggregating into a single repo. Requests without `repo` behave identically to before — fully additive.
+
+`POST /api/v1/prompts/refresh` accepts `repo` in the JSON body; `GET /api/v1/prompts` and `POST /api/v1/prompts/:promptName` accept `?repo=<url>` as a query parameter. Every response now includes a `source` field that echoes the override URL (or the env-var-configured repo, or `"built-in"`), with embedded credentials scrubbed via `sanitizeUrlForLogging`. The value is stable across requests for the same repo so CLI consumers can use it as a per-source tag in skill frontmatter and wipe only their own slice on subsequent invocations. Invalid `repo` values (non-`http(s)` schemes, path traversal in `subPath`, invalid branches, non-string types) return `400 VALIDATION_ERROR` without disturbing the env-var-configured cache.
+
+MVP scope notes: the existing `DOT_AI_GIT_TOKEN` is reused for all override URLs (per-repo tokens deferred), and the loader keeps a single-slot cache (sequential requests across different repos re-clone — per-repo cache map deferred). Per-request `branch` and `path` defaults match the env-var defaults (`main` and repo root) and can be exposed additively later. MCP `prompts/list` and `prompts/get` are unchanged — composition is CLI-driven.
+
+See the [REST API reference](https://devopstoolkit.ai/docs/mcp/api/rest-api) for full request/response shapes, validation rules, and credential-scrubbing examples, and the [Prompts tool guide](https://devopstoolkit.ai/docs/mcp/tools/prompts) for the multi-source composition workflow.

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dot-ai
 description: DevOps AI Toolkit - Intelligent Kubernetes deployment agent with AI-powered recommendations
 type: application
-version: "1.19.1"
-appVersion: "1.19.1"
+version: "1.20.0"
+appVersion: "1.20.0"
 home: https://github.com/vfarcic/dot-ai
 sources:
   - https://github.com/vfarcic/dot-ai

--- a/docs/ai-engine/api/rest-api.md
+++ b/docs/ai-engine/api/rest-api.md
@@ -243,6 +243,240 @@ For detailed parameter schemas and usage instructions:
 curl http://your-ingress-url/api/v1/openapi | jq '.paths'
 ```
 
+## Prompts Endpoints
+
+Three REST endpoints expose the shared prompt library. Each one accepts an optional `repo` parameter that, when supplied, fetches prompts from that repository instead of the one configured via `DOT_AI_USER_PROMPTS_REPO`. When `repo` is omitted, behavior is identical to the env-var-configured setup.
+
+See the [Shared Prompt Library](../tools/prompts.md) for the user-facing tool guide.
+
+### Endpoint Summary
+
+| Endpoint | `repo` parameter |
+|----------|------------------|
+| `POST /api/v1/prompts/refresh` | JSON body: `{ "repo": "<url>" }` |
+| `GET /api/v1/prompts` | Query string: `?repo=<url>` |
+| `POST /api/v1/prompts/:promptName` | Query string: `?repo=<url>` |
+
+### The `source` field
+
+Every response from these endpoints includes a `source` field identifying which repository the prompts came from.
+
+`source` values:
+
+| Request | `source` value |
+|---------|----------------|
+| `repo` parameter supplied | The supplied URL (credentials scrubbed) |
+| `repo` omitted, `DOT_AI_USER_PROMPTS_REPO` set | The env-var URL (credentials scrubbed) |
+| `repo` omitted, no env-var repo | `"built-in"` |
+
+**Credential scrubbing**: URLs with embedded credentials are scrubbed before being echoed back. `https://user:tok@host/repo` becomes `https://***:***@host/repo`. The transform is deterministic, so the same credentialed URL always produces the same `source` value across requests.
+
+### `POST /api/v1/prompts/refresh`
+
+Force-refreshes the prompts cache. Use this when you've pushed new prompts to the repository and don't want to wait for `DOT_AI_USER_PROMPTS_CACHE_TTL` to expire.
+
+**Request body** (all fields optional):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo` | string | Override repository URL (HTTPS). When supplied, bypasses `DOT_AI_USER_PROMPTS_REPO` for this request. |
+
+**Built-in case** (no env-var repo, no override):
+
+```bash
+curl -s -X POST http://localhost:3456/api/v1/prompts/refresh \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+```json
+{
+    "success": true,
+    "data": {
+        "refreshed": true,
+        "promptsLoaded": 11,
+        "source": "built-in"
+    },
+    "meta": {
+        "timestamp": "2026-05-26T19:51:50.367Z",
+        "requestId": "rest_1779825110366_3",
+        "version": "v1"
+    }
+}
+```
+
+**Per-request override case**:
+
+```bash
+curl -s -X POST http://localhost:3456/api/v1/prompts/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"repo":"https://github.com/vfarcic/dot-ai-user-prompts"}'
+```
+
+```json
+{
+    "success": true,
+    "data": {
+        "refreshed": true,
+        "promptsLoaded": 11,
+        "source": "https://github.com/vfarcic/dot-ai-user-prompts"
+    },
+    "meta": {
+        "timestamp": "2026-05-26T19:52:06.738Z",
+        "requestId": "rest_1779825126117_6",
+        "version": "v1"
+    }
+}
+```
+
+**Credential-scrubbing case**: a credentialed URL is echoed back scrubbed.
+
+```bash
+curl -s -X POST http://localhost:3456/api/v1/prompts/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"repo":"https://user:secrettoken@example.com/repo"}'
+```
+
+```json
+{
+    "success": true,
+    "data": {
+        "refreshed": true,
+        "promptsLoaded": 11,
+        "source": "https://***:***@example.com/repo"
+    }
+}
+```
+
+### `GET /api/v1/prompts`
+
+Lists all available prompts (built-in plus user-defined). Returns the prompt names, descriptions, and any declared arguments.
+
+**Query parameters** (all optional):
+
+| Parameter | Description |
+|-----------|-------------|
+| `repo` | Override repository URL (HTTPS). When supplied, bypasses `DOT_AI_USER_PROMPTS_REPO` for this request. |
+
+**Built-in case**:
+
+```bash
+curl -s http://localhost:3456/api/v1/prompts
+```
+
+Response (abbreviated — the full response carries every prompt's metadata):
+
+```json
+{
+    "success": true,
+    "data": {
+        "prompts": [
+            { "name": "generate-cicd", "description": "Generate intelligent CI/CD workflows..." },
+            { "name": "generate-dockerfile", "description": "Generate production-ready..." },
+            { "name": "prd-create", "description": "Create documentation-first PRDs..." }
+        ],
+        "source": "built-in"
+    }
+}
+```
+
+**Per-request override case**:
+
+```bash
+curl -s "http://localhost:3456/api/v1/prompts?repo=https://github.com/vfarcic/dot-ai-user-prompts"
+```
+
+The `source` field echoes the override URL (credentials scrubbed):
+
+```json
+{
+    "success": true,
+    "data": {
+        "prompts": [ /* … */ ],
+        "source": "https://github.com/vfarcic/dot-ai-user-prompts"
+    }
+}
+```
+
+### `POST /api/v1/prompts/:promptName`
+
+Returns the rendered content (`messages`, optional `files`) of a single prompt by name.
+
+**Query parameters** (all optional):
+
+| Parameter | Description |
+|-----------|-------------|
+| `repo` | Override repository URL (HTTPS). When supplied, bypasses `DOT_AI_USER_PROMPTS_REPO` for this request. |
+
+**Request body** (all fields optional):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `arguments` | object | Argument values for prompts that declare `arguments` in their frontmatter (substituted via `{{argumentName}}` placeholders). |
+
+**Per-request override example**:
+
+```bash
+curl -s -X POST "http://localhost:3456/api/v1/prompts/prd-create?repo=https://github.com/vfarcic/dot-ai-user-prompts" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+```json
+{
+    "success": true,
+    "data": {
+        "messages": [ /* prompt content */ ],
+        "source": "https://github.com/vfarcic/dot-ai-user-prompts"
+    }
+}
+```
+
+### Validation Rules for `repo`
+
+The server validates the `repo` parameter before performing any clone or pull. Invalid values return HTTP 400 with the standard error envelope.
+
+| Rule | Behavior |
+|------|----------|
+| Scheme must be `http` or `https` | Other schemes (`file://`, `ssh://`, `git://`) are rejected. |
+| `subPath` must be a safe relative path | `..` segments, absolute paths, and null bytes are rejected. (subPath is not exposed via REST in this release — the env-var defaults apply.) |
+| `branch` must match the git-safe character set | Validated when supplied programmatically. (Not exposed via REST in this release.) |
+| Credentials in the URL | Never echoed in error messages — scrubbed via `sanitizeUrlForLogging`. |
+
+**Validation-error envelope** (`HTTP 400`):
+
+```bash
+curl -s "http://localhost:3456/api/v1/prompts?repo=ssh://bad" \
+  -w "\nHTTP: %{http_code}\n"
+```
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid override repoUrl scheme: ssh: (only http and https are allowed) for ssh://bad"
+  },
+  "meta": {
+    "timestamp": "2026-05-26T19:52:37.389Z",
+    "requestId": "rest_1779825157389_10",
+    "version": "v1"
+  }
+}
+HTTP: 400
+```
+
+A request that fails validation never touches the loader, so the env-var-configured cache cannot be corrupted by a malformed override.
+
+### Server-side caveats for this release
+
+The `repo` parameter is the server's contract surface for composing prompts from multiple repositories. Each request still serves exactly one repo; how (and whether) callers compose responses from multiple requests is the caller's concern — see the [DevOps AI Toolkit CLI docs](https://devopstoolkit.ai/docs/cli) for the CLI-side composition flow.
+
+- **Single shared token**: All overrides authenticate with the same `DOT_AI_GIT_TOKEN`. Repos that live on different providers (e.g., GitHub + private GitLab) can't both be authenticated. Per-repo tokens are deferred.
+- **Single-slot cache**: The loader caches one repo at a time. Sequential requests against different repos re-clone each time (acceptable cost with `--depth 1` clones, but observable when alternating between repos within the TTL window).
+- **No URL allowlist / SSRF gate**: The endpoint assumes the caller is trusted. Don't expose the override surface to untrusted clients without an upstream gate.
+
+For the user-facing summary, see [Shared Prompt Library § Multi-source skills](../tools/prompts.md#multi-source-skills-via-the-per-request-repo-override).
 
 ## Workflows and Use Cases
 

--- a/docs/ai-engine/tools/prompts.md
+++ b/docs/ai-engine/tools/prompts.md
@@ -417,6 +417,30 @@ The feature is designed for graceful degradation:
 - **Solution**: Rename your prompt to a unique name
 - **Note**: Built-in prompts always take precedence
 
+### Multi-source skills via the per-request repo override
+
+For setups that want to pull prompts from **more than one** repository — for example, org-wide public skills on GitHub plus per-team private skills on a self-hosted GitLab — the server's three prompts REST endpoints (`POST /api/v1/prompts/refresh`, `GET /api/v1/prompts`, `POST /api/v1/prompts/:promptName`) accept an optional `repo` parameter that overrides `DOT_AI_USER_PROMPTS_REPO` for a single request. Each request still serves exactly one repository.
+
+Consumers (typically the [DevOps AI Toolkit CLI](https://devopstoolkit.ai/docs/cli)) drive multi-source composition by making multiple requests, one per source. See the CLI docs for the recommended composition flow (flag names, file tagging, per-source clean-up).
+
+When the override is not used, behavior is unchanged: the server falls back to `DOT_AI_USER_PROMPTS_REPO` (or to the built-in prompts when no env-var repo is configured).
+
+**Server-side caveats** for this release (the contract is additive, so these can be lifted later without breaking changes):
+
+| Caveat | Impact |
+|--------|--------|
+| Single shared `DOT_AI_GIT_TOKEN` | All overrides authenticate with the same token. Repos that live on different providers (e.g., GitHub + private GitLab) can't both be authenticated. |
+| Single-slot loader cache | Sequential requests against different repos re-clone each time. Clones are `--depth 1`, so the cost is small per call, but it's noticeable when alternating between repos within the TTL window. |
+| No URL allowlist | The server trusts the override URL. Don't expose this surface to untrusted callers without an upstream gate. |
+
+**When NOT to use the override**:
+
+- Inside a long-running query loop that alternates between repos (every alternation causes a re-clone — pin to one repo for the loop and switch outside it).
+- As a substitute for `DOT_AI_USER_PROMPTS_REPO` when you only have a single source. The env var is simpler and benefits from the cache TTL.
+- From untrusted clients (no SSRF guard in this release).
+
+See the [REST API reference](../api/rest-api.md#prompts-endpoints) for the full wire contract, the `source` field semantics, the validation rules, and the response envelopes returned by each endpoint.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/ai-engine/tools/prompts.md
+++ b/docs/ai-engine/tools/prompts.md
@@ -419,27 +419,27 @@ The feature is designed for graceful degradation:
 
 ### Multi-source skills via the per-request repo override
 
-For setups that want to pull prompts from **more than one** repository — for example, org-wide public skills on GitHub plus per-team private skills on a self-hosted GitLab — the server's three prompts REST endpoints (`POST /api/v1/prompts/refresh`, `GET /api/v1/prompts`, `POST /api/v1/prompts/:promptName`) accept an optional `repo` parameter that overrides `DOT_AI_USER_PROMPTS_REPO` for a single request. Each request still serves exactly one repository.
+When a single `DOT_AI_USER_PROMPTS_REPO` isn't enough — for example, you want org-wide public skills from one repository plus per-team private skills from another — run `dot-ai skills generate --repo <url>` (see the [CLI docs](https://devopstoolkit.ai/docs/cli) for the canonical reference) to fetch prompts from a specified repository for that invocation only, overriding the env-var default. Run the command multiple times — typically wired up as separate agent hooks, one per source — and the CLI tags each set of generated skills with its source so subsequent runs only wipe their own slice.
 
-Consumers (typically the [DevOps AI Toolkit CLI](https://devopstoolkit.ai/docs/cli)) drive multi-source composition by making multiple requests, one per source. See the CLI docs for the recommended composition flow (flag names, file tagging, per-source clean-up).
+Under the hood, each invocation talks to the server once and the server still serves exactly one repository per request; composition lives in the CLI, not the server.
 
-When the override is not used, behavior is unchanged: the server falls back to `DOT_AI_USER_PROMPTS_REPO` (or to the built-in prompts when no env-var repo is configured).
+When the override is not used, behavior is unchanged: the server falls back to `DOT_AI_USER_PROMPTS_REPO`, or to the built-in prompts when no env-var repo is configured.
 
 **Server-side caveats** for this release (the contract is additive, so these can be lifted later without breaking changes):
 
 | Caveat | Impact |
 |--------|--------|
 | Single shared `DOT_AI_GIT_TOKEN` | All overrides authenticate with the same token. Repos that live on different providers (e.g., GitHub + private GitLab) can't both be authenticated. |
-| Single-slot loader cache | Sequential requests against different repos re-clone each time. Clones are `--depth 1`, so the cost is small per call, but it's noticeable when alternating between repos within the TTL window. |
+| Single-slot loader cache | Sequential invocations against different repos re-clone each time. Clones are `--depth 1`, so the cost is small per call, but it's noticeable when alternating between repos within the TTL window. |
 | No URL allowlist | The server trusts the override URL. Don't expose this surface to untrusted callers without an upstream gate. |
 
 **When NOT to use the override**:
 
-- Inside a long-running query loop that alternates between repos (every alternation causes a re-clone — pin to one repo for the loop and switch outside it).
+- Inside a long-running agent loop that alternates between repos (every alternation causes a re-clone — pin to one repo for the loop and switch outside it).
 - As a substitute for `DOT_AI_USER_PROMPTS_REPO` when you only have a single source. The env var is simpler and benefits from the cache TTL.
 - From untrusted clients (no SSRF guard in this release).
 
-See the [REST API reference](../api/rest-api.md#prompts-endpoints) for the full wire contract, the `source` field semantics, the validation rules, and the response envelopes returned by each endpoint.
+See the [REST API reference](../api/rest-api.md#prompts-endpoints) for the full wire contract, the `source` field semantics, validation rules, and response envelopes returned by each endpoint — useful if you're building a custom MCP/HTTP client rather than using the CLI.
 
 ## Troubleshooting
 

--- a/mock-server/Dockerfile
+++ b/mock-server/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install
 
 # Copy TypeScript source files and config
 COPY tsconfig.json ./
-COPY server.ts routes.ts ./
+COPY *.ts ./
 
 # Build TypeScript to JavaScript
 RUN npm run build

--- a/mock-server/fixtures/prompts/get-success.json
+++ b/mock-server/fixtures/prompts/get-success.json
@@ -20,7 +20,8 @@
         "path": "templates/pod-debug.yaml",
         "content": "YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IGRlYnVnLXBvZAogIG5hbWVzcGFjZTogZGVmYXVsdApzcGVjOgogIGNvbnRhaW5lcnM6CiAgICAtIG5hbWU6IGRlYnVnCiAgICAgIGltYWdlOiBidXN5Ym94OmxhdGVzdAogICAgICBjb21tYW5kOiBbInNsZWVwIiwgIjM2MDAiXQogICAgICByZXNvdXJjZXM6CiAgICAgICAgbGltaXRzOgogICAgICAgICAgbWVtb3J5OiAiMTI4TWkiCiAgICAgICAgICBjcHU6ICIyNTBtIgo="
       }
-    ]
+    ],
+    "source": "built-in"
   },
   "meta": {
     "timestamp": "2024-01-15T10:30:00.000Z",

--- a/mock-server/fixtures/prompts/list-success.json
+++ b/mock-server/fixtures/prompts/list-success.json
@@ -66,7 +66,8 @@
           }
         ]
       }
-    ]
+    ],
+    "source": "built-in"
   },
   "meta": {
     "timestamp": "2024-01-15T10:30:00.000Z",

--- a/mock-server/fixtures/prompts/refresh-success.json
+++ b/mock-server/fixtures/prompts/refresh-success.json
@@ -3,7 +3,7 @@
   "data": {
     "refreshed": true,
     "promptsLoaded": 4,
-    "source": "built-in+repository"
+    "source": "built-in"
   },
   "meta": {
     "timestamp": "2024-01-15T10:30:00.000Z",

--- a/mock-server/prompts-override.ts
+++ b/mock-server/prompts-override.ts
@@ -1,0 +1,36 @@
+/**
+ * Mock-server helpers for PRD #581: per-request user prompts repo override.
+ *
+ * The real server validates and clones the override repo. The mock-server only
+ * needs to mirror the wire contract — specifically, when a `repo` parameter is
+ * supplied the response's `data.source` echoes that URL verbatim so CLI tagging
+ * tests can verify the round-trip.
+ *
+ * Extracted from server.ts so it can be unit-tested without starting the HTTP
+ * listener.
+ */
+
+export function isPromptsRoutePath(path: string): boolean {
+  return (
+    path === '/api/v1/prompts' ||
+    path === '/api/v1/prompts/refresh' ||
+    /^\/api\/v1\/prompts\/[^/]+$/.test(path)
+  );
+}
+
+export function applyPromptsRepoOverride(
+  fixture: unknown,
+  repo: string | undefined
+): unknown {
+  if (!repo) return fixture;
+  if (!fixture || typeof fixture !== 'object') return fixture;
+  const f = fixture as { data?: unknown };
+  if (!f.data || typeof f.data !== 'object') return fixture;
+  return {
+    ...f,
+    data: {
+      ...(f.data as Record<string, unknown>),
+      source: repo,
+    },
+  };
+}

--- a/mock-server/read-json-body.ts
+++ b/mock-server/read-json-body.ts
@@ -1,0 +1,83 @@
+/**
+ * Mock-server JSON body reader with a hard size cap (PRD #581 F4).
+ *
+ * The mock-server is a developer tool, but it's still new code we ship.
+ * Uncapped buffering of the request body trivially DOSes the process with a
+ * multi-GB POST. This helper enforces a 1 MB cap two ways:
+ *   - upfront via the Content-Length header (so we never start buffering)
+ *   - defense-in-depth via accumulated chunk size during read (in case the
+ *     header lies or is omitted)
+ *
+ * Extracted from server.ts so it can be unit-tested without starting the
+ * HTTP listener.
+ */
+
+import type { IncomingMessage } from 'node:http';
+
+export const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MB
+
+export class BodyTooLargeError extends Error {
+  public readonly limit: number;
+  constructor(limit: number) {
+    super(`Request body exceeds ${limit} bytes`);
+    this.name = 'BodyTooLargeError';
+    this.limit = limit;
+  }
+}
+
+/**
+ * Buffer the entire request body and parse as JSON.
+ * Returns undefined when the body is empty or not valid JSON, so callers can
+ * treat the no-body case the same as the empty-object case.
+ * Throws BodyTooLargeError when the body would exceed MAX_BODY_BYTES.
+ */
+export async function readJsonBody(
+  req: IncomingMessage
+): Promise<Record<string, unknown> | undefined> {
+  const declaredLen = req.headers
+    ? parseInt((req.headers['content-length'] as string | undefined) || '0', 10)
+    : 0;
+  if (!Number.isNaN(declaredLen) && declaredLen > MAX_BODY_BYTES) {
+    throw new BodyTooLargeError(MAX_BODY_BYTES);
+  }
+
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let received = 0;
+    let aborted = false;
+    req.on('data', chunk => {
+      if (aborted) return;
+      received += chunk.length;
+      if (received > MAX_BODY_BYTES) {
+        aborted = true;
+        // Stop receiving; the caller will respond with 413 and the connection
+        // is no longer interesting for this request.
+        req.destroy();
+        reject(new BodyTooLargeError(MAX_BODY_BYTES));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (aborted) return;
+      const raw = Buffer.concat(chunks).toString('utf-8').trim();
+      if (!raw) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          resolve(parsed as Record<string, unknown>);
+        } else {
+          resolve(undefined);
+        }
+      } catch {
+        resolve(undefined);
+      }
+    });
+    req.on('error', () => {
+      if (!aborted) resolve(undefined);
+    });
+  });
+}

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -12,6 +12,11 @@ import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { URL, fileURLToPath } from 'node:url';
 import { matchRoute, getAllRoutes } from './routes.js';
+import {
+  applyPromptsRepoOverride,
+  isPromptsRoutePath,
+} from './prompts-override.js';
+import { BodyTooLargeError, readJsonBody } from './read-json-body.js';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -26,7 +31,10 @@ const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
  */
 function setCorsHeaders(res: ServerResponse): void {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.setHeader(
+    'Access-Control-Allow-Methods',
+    'GET, POST, PUT, DELETE, OPTIONS'
+  );
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 }
 
@@ -50,7 +58,10 @@ async function loadFixture(fixturePath: string): Promise<unknown> {
 /**
  * Handle incoming HTTP requests
  */
-async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<void> {
   setCorsHeaders(res);
 
   // Handle CORS preflight
@@ -76,7 +87,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
 
   // List all available routes (for debugging)
   if (path === '/routes' && method === 'GET') {
-    const routes = getAllRoutes().map((r) => ({
+    const routes = getAllRoutes().map(r => ({
       method: r.method,
       path: r.path,
       description: r.description,
@@ -104,7 +115,8 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
 
   // Handle redirect routes (e.g., /authorize)
   if (route.redirect) {
-    const redirectUri = url.searchParams.get('redirect_uri') || 'http://localhost:3000/callback';
+    const redirectUri =
+      url.searchParams.get('redirect_uri') || 'http://localhost:3000/callback';
     const state = url.searchParams.get('state') || '';
     const redirectUrl = new URL(redirectUri);
     redirectUrl.searchParams.set('code', 'mock-authorization-code-12345');
@@ -133,12 +145,43 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     return;
   }
 
-  // Load and return fixture
+  // Load and return fixture. For prompts routes, apply the optional `repo`
+  // override (PRD #581) so the response's `source` field echoes the supplied
+  // URL — matching the real server's contract that the CLI relies on for
+  // skill tagging.
   try {
     const fixture = await loadFixture(route.fixture);
-    sendJson(res, 200, fixture);
+    let payload: unknown = fixture;
+    if (isPromptsRoutePath(route.path)) {
+      let repo: string | undefined = url.searchParams.get('repo') || undefined;
+      if (
+        !repo &&
+        method === 'POST' &&
+        route.path === '/api/v1/prompts/refresh'
+      ) {
+        const body = await readJsonBody(req);
+        const bodyRepo = body?.['repo'];
+        if (typeof bodyRepo === 'string' && bodyRepo.trim()) {
+          repo = bodyRepo.trim();
+        }
+      }
+      payload = applyPromptsRepoOverride(fixture, repo);
+    }
+    sendJson(res, 200, payload);
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    // F4: oversized body → 413, not 500.
+    if (error instanceof BodyTooLargeError) {
+      sendJson(res, 413, {
+        success: false,
+        error: {
+          code: 'PAYLOAD_TOO_LARGE',
+          message: error.message,
+        },
+      });
+      return;
+    }
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
     sendJson(res, 500, {
       success: false,
       error: {
@@ -154,7 +197,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
  * Start the server
  */
 const server = createServer((req, res) => {
-  handleRequest(req, res).catch((error) => {
+  handleRequest(req, res).catch(error => {
     console.error('Unhandled error:', error);
     sendJson(res, 500, {
       success: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vfarcic/dot-ai",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vfarcic/dot-ai",
-      "version": "1.19.1",
+      "version": "1.20.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/alibaba": "^1.0.13",
@@ -57,6 +57,7 @@
         "globals": "^17.2.0",
         "prettier": "^3.0.0",
         "ts-node": "^10.9.0",
+        "tsx": "^4.22.3",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.54.0",
         "uuid": "^14.0.0",
@@ -70,12 +71,28 @@
       }
     },
     "node_modules/@ai-sdk/alibaba": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/alibaba/-/alibaba-1.0.23.tgz",
-      "integrity": "sha512-IH1vuFCJZacj8UPMrOPCdesFNv86hf6/c/0h19OfeoW4zHeBpW9ssCKUbQ+V68EBZto5aEDr/SnRn1pIuGvgfA==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/alibaba/-/alibaba-1.0.25.tgz",
+      "integrity": "sha512-2XkJWCZ57ZahuXyz3FNHvcK6RpcEYHy39MJ7DZ8l04O2PBq2nPzkDi2rGz92JST+Q3kAJ/d8zI2OMk/ovjaNzg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/openai-compatible": "2.0.47",
+        "@ai-sdk/openai-compatible": "2.0.48",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/alibaba/node_modules/@ai-sdk/openai-compatible": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.48.tgz",
+      "integrity": "sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
       },
@@ -87,12 +104,12 @@
       }
     },
     "node_modules/@ai-sdk/amazon-bedrock": {
-      "version": "4.0.107",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.107.tgz",
-      "integrity": "sha512-8nT08pGPy25rleJNk56ep00UHK6kCtCmu+ZNqVVSSPDieADlIZqcaN1iRXAFBoCH0Fb9F6C2EjFDaySdsargfQ==",
+      "version": "4.0.111",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.111.tgz",
+      "integrity": "sha512-cH71k96tcnLuq1x3xi0KP384Jxio8qM6VQzHDUfU4OuX2P83FC/pBvksR5YVRm17GdQliAfR1t5o6z1iJRtfpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "3.0.78",
+        "@ai-sdk/anthropic": "3.0.81",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@smithy/eventstream-codec": "^4.0.1",
@@ -107,9 +124,9 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.78",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.78.tgz",
-      "integrity": "sha512-0OY12G20cUt6iU6htpEA1491Oz++NVxZxlmWGX4B7rSbeZ5pnDmOu6YtW9BKzdZlNx5Gn23i6WMxyZFoMKNcgA==",
+      "version": "3.0.81",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.81.tgz",
+      "integrity": "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
@@ -322,6 +339,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -331,6 +371,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -761,7 +1243,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2153,7 +2634,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2265,7 +2745,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2587,7 +3066,6 @@
       "integrity": "sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.6",
         "fflate": "^0.8.2",
@@ -2637,7 +3115,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2691,7 +3168,6 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.184.tgz",
       "integrity": "sha512-j//zHkKvj5ra27l8izHco8cj1g1Pr7vx1ZK+hrzrkHvndgIRmdfZKOb6+RAPpvbk42qGIsuYvlYbGlVAu3erNQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.115",
         "@ai-sdk/provider": "3.0.10",
@@ -3200,7 +3676,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3622,7 +4097,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3918,6 +4392,48 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3952,7 +4468,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4223,7 +4738,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4671,7 +5185,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
       "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4878,7 +5391,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5832,7 +6344,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6708,6 +7219,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6757,7 +7287,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6872,7 +7401,6 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6951,7 +7479,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -7128,7 +7655,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7224,7 +7750,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -322,29 +322,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -784,6 +761,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1445,9 +1423,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1465,9 +1440,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1485,9 +1457,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1505,9 +1474,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1525,9 +1491,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1545,9 +1508,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1640,9 +1600,6 @@
       "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2196,6 +2153,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2307,6 +2265,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2628,6 +2587,7 @@
       "integrity": "sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.6",
         "fflate": "^0.8.2",
@@ -2677,6 +2637,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2730,6 +2691,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.184.tgz",
       "integrity": "sha512-j//zHkKvj5ra27l8izHco8cj1g1Pr7vx1ZK+hrzrkHvndgIRmdfZKOb6+RAPpvbk42qGIsuYvlYbGlVAu3erNQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.115",
         "@ai-sdk/provider": "3.0.10",
@@ -3238,6 +3200,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3659,6 +3622,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3988,6 +3952,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4258,6 +4223,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4701,10 +4667,11 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
-      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4911,6 +4878,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5202,9 +5170,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5226,9 +5191,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5250,9 +5212,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5274,9 +5233,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5876,6 +5832,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6800,6 +6757,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6914,6 +6872,7 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6992,6 +6951,7 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -7168,6 +7128,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7263,6 +7224,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vfarcic/dot-ai",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "AI-powered development productivity platform that enhances software development workflows through intelligent automation and AI-driven assistance",
   "mcpName": "io.github.vfarcic/dot-ai",
   "main": "dist/index.js",
@@ -101,6 +101,7 @@
     "globals": "^17.2.0",
     "prettier": "^3.0.0",
     "ts-node": "^10.9.0",
+    "tsx": "^4.22.3",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.54.0",
     "uuid": "^14.0.0",

--- a/prds/581-per-request-user-prompts-repo.md
+++ b/prds/581-per-request-user-prompts-repo.md
@@ -1,6 +1,6 @@
 # PRD #581: Per-Request User Prompts Repository Override
 
-**Status**: Draft
+**Status**: Implementation Complete — awaiting CLI companion PRD merge
 **Priority**: Medium
 **Related Issue**: #575 (discussion); CLI companion PRD lives in `vfarcic/dot-ai-cli`
 
@@ -139,8 +139,37 @@ For requests with no override, `source` reflects the env-var-configured repo URL
 
 ## Milestones
 
-- [ ] Loader change: `loadUserPrompts` accepts an optional override config; existing call sites pass `undefined`. New helper `getUserPromptsConfigFromOverride()` constructs a `UserPromptsConfig` from the override.
-- [ ] REST endpoints: `POST /api/v1/prompts/refresh` accepts `{ repo }`; `GET /api/v1/prompts` and `POST /api/v1/prompts/:name` accept `?repo=...`. All thread the override through to the loader. `source` field reflects the override URL when present.
-- [ ] Integration tests covering: no-override path is byte-identical; override path fetches the correct repo; invalid URL returns error without corrupting cache; logs scrub credentials in override URL.
-- [ ] Documentation update: `docs/` describes the new parameter, its defaults, and the single-token / single-cache-slot caveats. Reference the CLI companion PRD.
+- [x] Loader change: `loadUserPrompts` accepts an optional override config; existing call sites pass `undefined`. New helper `getUserPromptsConfigFromOverride()` constructs a `UserPromptsConfig` from the override.
+- [x] REST endpoints: `POST /api/v1/prompts/refresh` accepts `{ repo }`; `GET /api/v1/prompts` and `POST /api/v1/prompts/:name` accept `?repo=...`. All thread the override through to the loader. `source` field reflects the override URL when present (credentials scrubbed via `sanitizeUrlForLogging`).
+- [x] Mock-server parity: `mock-server/routes.ts` and `mock-server/fixtures/prompts/` updated so all three prompts endpoints accept the optional `repo` parameter and echo it back in `source`. Body-size cap (1 MB) added to `mock-server/read-json-body.ts`. Mock image republish via `publish-mock-server` happens at release time.
+- [x] Integration tests covering: no-override path is byte-identical; override path validation returns 400 with credentials scrubbed; logs scrub credentials in override URL. Coverage delivered across layers: 18 loader unit tests (git boundary mocked), 7 `computePromptsSource` unit tests (incl. stability + credential scrubbing), 6 REST integration tests (validation paths), 6 mock-server unit tests, 7 request-log scrubbing unit tests, 6 body-size-cap tests. Happy-path REST integration test attempted but architecturally blocked by single-slot loader cache shared across vitest fork-pool files (PRD-deferred fix); rationale documented at `tests/integration/tools/prompts.test.ts:510-530`.
+- [x] Documentation update: `docs/` describes the new parameter, its defaults, and the single-token / single-cache-slot caveats. Reference the CLI companion PRD. Landing pages: [`docs/ai-engine/api/rest-api.md` § Prompts Endpoints](../docs/ai-engine/api/rest-api.md#prompts-endpoints) and [`docs/ai-engine/tools/prompts.md` § Multi-source skills via the per-request repo override](../docs/ai-engine/tools/prompts.md#multi-source-skills-via-the-per-request-repo-override). Changelog fragment at `changelog.d/581.feature.md`.
 - [ ] CLI companion PRD merged in `vfarcic/dot-ai-cli` and linked from this PRD.
+
+## Instructions for the dot-ai-cli companion team
+
+Before this PRD's PR is merged, post these instructions to the dot-ai-cli companion team so they can wire `dot-ai skills generate --repo <url>` against the updated mock and verify their tagging logic end-to-end.
+
+### What changed in the mock-server contract
+
+The mock-server (`ghcr.io/vfarcic/dot-ai-mock-server`, image republished as part of M2b) now mirrors the production behavior for all three prompts endpoints:
+
+| Endpoint | Where `repo` is accepted |
+| --- | --- |
+| `POST /api/v1/prompts/refresh` | JSON body: `{ "repo": "<url>" }` |
+| `GET /api/v1/prompts` | Query string: `?repo=<url>` |
+| `POST /api/v1/prompts/:name` | Query string: `?repo=<url>` |
+
+When `repo` is supplied, the response includes a `source` field that echoes that URL verbatim. When `repo` is omitted, `source` reflects the env-var-configured repo URL (or `"built-in"` if no env-var repo is configured) — same value the CLI should write into the skill frontmatter.
+
+### What the CLI must verify against the new mock image
+
+1. `dot-ai skills generate --repo <url>` sends the URL on every relevant request (refresh body + list query + get query) and surfaces a clear error if the server returns 4xx/5xx.
+2. Each skill file written by the CLI carries a `source:` frontmatter field whose value is the exact `source` string the server returned for that request.
+3. A second invocation `dot-ai skills generate --repo <other-url>` does NOT wipe skills written by the first run — only those whose `source:` matches `<other-url>`.
+4. `dot-ai skills generate` (no `--repo`) writes skills tagged with the `source` value returned for the no-override case — which is `"built-in"` when no env-var repo is configured.
+5. URLs with embedded credentials are not echoed back into log output or skill frontmatter.
+
+### Mock image version pinning
+
+Pin to the mock image tag that publishes from this PRD's branch (the M2b publish step records the tag in the PR description). Older mock images don't accept the `repo` parameter and will silently ignore it — CLI tests pinned to the old tag will look like they pass while actually exercising no override behavior.

--- a/src/core/user-prompts-loader.ts
+++ b/src/core/user-prompts-loader.ts
@@ -98,21 +98,23 @@ export function getUserPromptsConfig(): UserPromptsConfig | null {
  *   - no override, env-var configured → DOT_AI_USER_PROMPTS_REPO
  *   - no override, no env-var         → "built-in"
  *
- * URLs are passed through sanitizeUrlForLogging before returning, so a
- * credential-bearing input (e.g. https://user:token@host/repo) does not leak
- * into the response body, the server logs, or the on-disk skill frontmatter
- * the CLI writes. Stability is preserved: sanitizeUrlForLogging is
- * deterministic, so two identical credential-bearing inputs produce the same
+ * URLs flow through scrubSourceUrl before returning, which scrubs BOTH:
+ *   - userinfo credentials (https://user:token@host/repo)
+ *   - credential-bearing query params (?access_token=... etc — CodeRabbit
+ *     Major A)
+ *
+ * Stability is preserved: scrubSourceUrl is deterministic (fixed `***`
+ * placeholder), so two identical credential-bearing inputs produce the same
  * scrubbed source — keeping the CLI's "wipe only my own slice" invariant
  * intact.
  */
 export function computePromptsSource(override?: UserPromptsOverride): string {
   if (override?.repoUrl) {
-    return sanitizeUrlForLogging(override.repoUrl);
+    return scrubSourceUrl(override.repoUrl);
   }
   const envRepo = process.env.DOT_AI_USER_PROMPTS_REPO;
   if (envRepo) {
-    return sanitizeUrlForLogging(envRepo);
+    return scrubSourceUrl(envRepo);
   }
   return 'built-in';
 }
@@ -223,6 +225,48 @@ export function sanitizeUrlForLogging(url: string): string {
   } catch {
     // If URL parsing fails, do basic sanitization
     return url.replace(/\/\/[^@]+@/, '//***@');
+  }
+}
+
+/**
+ * Query-param names whose values look credential-bearing. Conservative
+ * allowlist-on-redaction — case-insensitive substring match.
+ */
+const CREDENTIAL_PARAM_RE = /token|key|secret|password|auth|credential/i;
+
+/**
+ * Source-only deep scrub for URLs that flow into the response body and the
+ * on-disk skill frontmatter the CLI writes (PRD #581 / CodeRabbit Major A).
+ *
+ * In addition to the userinfo scrub from sanitizeUrlForLogging, redacts the
+ * VALUES of query parameters whose names look credential-bearing (token, key,
+ * secret, password, auth, credential — case-insensitive). The placeholder is
+ * a fixed string so the output is deterministic — same input always produces
+ * the same source, preserving the CLI's "tag-and-wipe-by-source" invariant.
+ *
+ * Scope: ONLY called from computePromptsSource. NOT a general-purpose
+ * replacement for sanitizeUrlForLogging — the broader hygiene of the shared
+ * helper was deferred per the M2 follow-up scope.
+ */
+export function scrubSourceUrl(url: string): string {
+  // Userinfo scrub first; this also handles "//user:pass@" via the regex
+  // fallback when URL parsing fails.
+  const userinfoScrubbed = sanitizeUrlForLogging(url);
+  try {
+    const parsed = new URL(userinfoScrubbed);
+    let mutated = false;
+    for (const name of [...parsed.searchParams.keys()]) {
+      if (CREDENTIAL_PARAM_RE.test(name)) {
+        parsed.searchParams.set(name, '***');
+        mutated = true;
+      }
+    }
+    return mutated ? parsed.toString() : userinfoScrubbed;
+  } catch {
+    // Unparseable; return the userinfo-scrubbed form unchanged. Query-param
+    // scrubbing on unparseable URLs is meaningless — there's no reliable
+    // boundary to walk.
+    return userinfoScrubbed;
   }
 }
 

--- a/src/core/user-prompts-loader.ts
+++ b/src/core/user-prompts-loader.ts
@@ -16,7 +16,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { Logger } from './error-handling';
-import { cloneRepo, pullRepo, scrubCredentials } from './git-utils';
+import {
+  cloneRepo,
+  pullRepo,
+  sanitizeRelativePath,
+  scrubCredentials,
+} from './git-utils';
 import { Prompt, PromptFile, loadPromptFile } from '../tools/prompts';
 
 /**
@@ -31,11 +36,27 @@ export interface UserPromptsConfig {
 }
 
 /**
- * Cache state for tracking repository freshness
+ * Per-request override for user prompts repository.
+ * When supplied to loadUserPrompts(), bypasses DOT_AI_USER_PROMPTS_REPO env vars
+ * for that call while reusing DOT_AI_GIT_TOKEN and the cache TTL.
+ */
+export interface UserPromptsOverride {
+  repoUrl: string;
+  branch?: string;
+  subPath?: string;
+}
+
+/**
+ * Cache state for tracking repository freshness.
+ * Cache is invalidated when any of repoUrl, branch, or subPath changes,
+ * so we record all three on every clone.
  */
 interface CacheState {
   lastPullTime: number;
   localPath: string;
+  repoUrl: string;
+  branch: string;
+  subPath: string;
 }
 
 // In-memory cache state (persists across requests within same process)
@@ -64,6 +85,100 @@ export function getUserPromptsConfig(): UserPromptsConfig | null {
     repoUrl,
     branch: process.env.DOT_AI_USER_PROMPTS_BRANCH || 'main',
     subPath: process.env.DOT_AI_USER_PROMPTS_PATH || '',
+    gitToken: process.env.DOT_AI_GIT_TOKEN,
+    cacheTtlSeconds,
+  };
+}
+
+/**
+ * Compute the `source` value the REST endpoints expose in their responses.
+ * The CLI (vfarcic/dot-ai-cli) uses this string verbatim to tag the skill
+ * files it writes, so:
+ *   - per-request override supplied  → override.repoUrl
+ *   - no override, env-var configured → DOT_AI_USER_PROMPTS_REPO
+ *   - no override, no env-var         → "built-in"
+ *
+ * URLs are passed through sanitizeUrlForLogging before returning, so a
+ * credential-bearing input (e.g. https://user:token@host/repo) does not leak
+ * into the response body, the server logs, or the on-disk skill frontmatter
+ * the CLI writes. Stability is preserved: sanitizeUrlForLogging is
+ * deterministic, so two identical credential-bearing inputs produce the same
+ * scrubbed source — keeping the CLI's "wipe only my own slice" invariant
+ * intact.
+ */
+export function computePromptsSource(override?: UserPromptsOverride): string {
+  if (override?.repoUrl) {
+    return sanitizeUrlForLogging(override.repoUrl);
+  }
+  const envRepo = process.env.DOT_AI_USER_PROMPTS_REPO;
+  if (envRepo) {
+    return sanitizeUrlForLogging(envRepo);
+  }
+  return 'built-in';
+}
+
+/**
+ * Build a UserPromptsConfig from a per-request override.
+ * Reuses DOT_AI_GIT_TOKEN and DOT_AI_USER_PROMPTS_CACHE_TTL from the environment;
+ * branch and subPath fall back to the same defaults as the env-var path.
+ *
+ * Validates the override inputs before returning:
+ *   - repoUrl scheme must be http or https (prevents file://, ssh://, etc.)
+ *   - subPath must be a relative path inside the cache directory (no '..',
+ *     no absolute, no null bytes)
+ *   - branch must match the git-safe character set used elsewhere
+ *
+ * Throws Error with a credential-scrubbed message on any validation failure.
+ */
+export function getUserPromptsConfigFromOverride(
+  override: UserPromptsOverride
+): UserPromptsConfig {
+  // F1: repoUrl scheme must be http/https
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(override.repoUrl);
+  } catch {
+    throw new Error(
+      `Invalid override repoUrl: ${sanitizeUrlForLogging(override.repoUrl)} (failed to parse)`
+    );
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error(
+      `Invalid override repoUrl scheme: ${parsedUrl.protocol} (only http and https are allowed) for ${sanitizeUrlForLogging(override.repoUrl)}`
+    );
+  }
+
+  // F2: subPath must be a safe relative path
+  let normalizedSubPath = '';
+  if (override.subPath) {
+    if (override.subPath.includes('\0')) {
+      throw new Error('Invalid override subPath: contains null byte');
+    }
+    try {
+      normalizedSubPath = sanitizeRelativePath(override.subPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Invalid override subPath: ${message}`, { cause: error });
+    }
+  }
+
+  // F3: branch (if supplied) must match the git-safe character set
+  const branch = override.branch || 'main';
+  if (override.branch !== undefined && !isValidGitBranch(override.branch)) {
+    throw new Error(`Invalid override branch name: ${override.branch}`);
+  }
+
+  const parsedTtl = parseInt(
+    process.env.DOT_AI_USER_PROMPTS_CACHE_TTL || '86400',
+    10
+  );
+  const cacheTtlSeconds =
+    Number.isNaN(parsedTtl) || parsedTtl < 0 ? 86400 : parsedTtl;
+
+  return {
+    repoUrl: override.repoUrl,
+    branch,
+    subPath: normalizedSubPath,
     gitToken: process.env.DOT_AI_GIT_TOKEN,
     cacheTtlSeconds,
   };
@@ -239,11 +354,38 @@ async function ensureRepository(
   const now = Date.now();
   const ttlMs = config.cacheTtlSeconds * 1000;
 
-  // Check if we need to clone or pull
-  if (!cacheState || !fs.existsSync(cacheState.localPath)) {
-    // First time or cache directory was deleted - clone
+  // Check if we need to clone or pull. The cache is invalidated when any of
+  // (repoUrl, branch, subPath) differs from the cached entry so that, for
+  // example, a future override with a different branch but the same repoUrl
+  // won't serve stale content from the previous clone.
+  const cacheMisses =
+    cacheState !== null &&
+    (cacheState.repoUrl !== config.repoUrl ||
+      cacheState.branch !== config.branch ||
+      cacheState.subPath !== config.subPath);
+  if (!cacheState || !fs.existsSync(cacheState.localPath) || cacheMisses) {
+    // First time, cache directory deleted, or cached coordinates differ - clone fresh
+    if (cacheMisses) {
+      logger.debug(
+        'Cached repo coordinates differ from requested, re-cloning',
+        {
+          cachedUrl: sanitizeUrlForLogging(cacheState!.repoUrl),
+          cachedBranch: cacheState!.branch,
+          cachedSubPath: cacheState!.subPath,
+          requestedUrl: sanitizeUrlForLogging(config.repoUrl),
+          requestedBranch: config.branch,
+          requestedSubPath: config.subPath,
+        }
+      );
+    }
     await cloneRepository(config, localPath, logger);
-    cacheState = { lastPullTime: now, localPath };
+    cacheState = {
+      lastPullTime: now,
+      localPath,
+      repoUrl: config.repoUrl,
+      branch: config.branch,
+      subPath: config.subPath,
+    };
   } else if (forceRefresh || now - cacheState.lastPullTime >= ttlMs) {
     // Cache expired or force refresh - pull
     await pullRepository(config, localPath, logger);
@@ -334,14 +476,34 @@ function loadSkillFolder(
 }
 
 /**
- * Load user prompts from the configured git repository
- * Returns empty array if not configured or on error
+ * Load user prompts from a git repository.
+ *
+ * When `override` is supplied, fetches from that repository for this call only,
+ * ignoring DOT_AI_USER_PROMPTS_REPO env vars. Otherwise, uses env-var configuration.
+ * Returns empty array if not configured or on error.
  */
 export async function loadUserPrompts(
   logger: Logger,
-  forceRefresh: boolean = false
+  forceRefresh: boolean = false,
+  override?: UserPromptsOverride
 ): Promise<Prompt[]> {
-  const config = getUserPromptsConfig();
+  let config: UserPromptsConfig | null;
+  try {
+    // Override validation can throw on bad scheme / traversal / branch — keep
+    // the call inside the catch so a malformed per-request override returns
+    // [] rather than propagating an exception to the caller.
+    config = override
+      ? getUserPromptsConfigFromOverride(override)
+      : getUserPromptsConfig();
+  } catch (error) {
+    const rawMessage = error instanceof Error ? error.message : 'Unknown error';
+    const safeMessage = scrubCredentials(rawMessage);
+    logger.error(
+      'Failed to load user prompts, falling back to built-in only',
+      new Error(safeMessage)
+    );
+    return [];
+  }
 
   if (!config) {
     logger.debug(
@@ -374,7 +536,10 @@ export async function loadUserPrompts(
         const prompt = loadPromptFile(filePath, 'user');
         prompts.push(prompt);
         loadedNames.add(prompt.name);
-        logger.debug('Loaded user prompt', { name: prompt.name, file: entry.name });
+        logger.debug('Loaded user prompt', {
+          name: prompt.name,
+          file: entry.name,
+        });
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error';
@@ -386,17 +551,22 @@ export async function loadUserPrompts(
     }
 
     // 2. Load skill folders (directories containing SKILL.md)
-    const directories = entries.filter(e => e.isDirectory() && !e.name.startsWith('.'));
+    const directories = entries.filter(
+      e => e.isDirectory() && !e.name.startsWith('.')
+    );
     for (const dir of directories) {
       try {
         const dirPath = path.join(promptsDir, dir.name);
         const prompt = loadSkillFolder(dirPath, dir.name, logger);
         if (prompt) {
           if (loadedNames.has(prompt.name)) {
-            logger.warn('Skill folder name collision with existing prompt, skipping', {
-              name: prompt.name,
-              dir: dir.name,
-            });
+            logger.warn(
+              'Skill folder name collision with existing prompt, skipping',
+              {
+                name: prompt.name,
+                dir: dir.name,
+              }
+            );
             continue;
           }
           prompts.push(prompt);
@@ -424,11 +594,17 @@ export async function loadUserPrompts(
 
     return prompts;
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error';
+    // F5: scrub credentials before they reach loggers/callers. Underlying git
+    // errors can echo the authenticated URL (with embedded token) verbatim.
+    const rawMessage = error instanceof Error ? error.message : 'Unknown error';
+    const safeMessage = scrubCredentials(
+      config.gitToken
+        ? rawMessage.replaceAll(config.gitToken, '***')
+        : rawMessage
+    );
     logger.error(
       'Failed to load user prompts, falling back to built-in only',
-      new Error(errorMessage)
+      new Error(safeMessage)
     );
     return [];
   }

--- a/src/interfaces/rest-api.ts
+++ b/src/interfaces/rest-api.ts
@@ -20,6 +20,13 @@ import {
   handlePromptsGetRequest,
   loadAllPrompts,
 } from '../tools/prompts';
+import {
+  computePromptsSource,
+  getUserPromptsConfigFromOverride,
+  sanitizeUrlForLogging,
+  UserPromptsOverride,
+} from '../core/user-prompts-loader';
+import { scrubCredentials } from '../core/git-utils';
 import { GenericSessionManager } from '../core/generic-session-manager';
 import {
   getSessionEventBus,
@@ -67,6 +74,33 @@ import {
   filterAuthorizedTools,
   logUserManagementOperation,
 } from '../core/rbac';
+
+/**
+ * F3: req.url is logged on every request; with PRD #581 the query string may
+ * carry `?repo=<user-supplied-url>` whose value can include credentials. This
+ * helper rewrites the `repo` value to its credential-scrubbed form so the
+ * raw token doesn't reach the log. Everything else is preserved verbatim. On
+ * any parse failure the original string is returned (defensive — better to
+ * log a slightly noisy URL than to drop the entire request log).
+ */
+export function sanitizeRequestUrlForLogging(
+  url: string | undefined
+): string | undefined {
+  if (!url) return url;
+  if (!url.includes('repo=')) return url;
+  try {
+    // req.url is path-relative; provide a dummy base for URL parsing.
+    const parsed = new URL(url, 'http://internal.invalid');
+    const repo = parsed.searchParams.get('repo');
+    if (repo) {
+      parsed.searchParams.set('repo', sanitizeUrlForLogging(repo));
+    }
+    // Return path + search only (drop the dummy base).
+    return parsed.pathname + parsed.search + parsed.hash;
+  } catch {
+    return url;
+  }
+}
 
 /**
  * HTTP status codes for REST responses
@@ -273,7 +307,10 @@ export class RestApiRouter {
       this.logger.debug('REST API request received', {
         requestId,
         method: req.method,
-        url: req.url,
+        // F3: req.url may carry a `?repo=<user-supplied-url>` whose query
+        // value includes credentials (PRD #581). Sanitize that single
+        // value before logging.
+        url: sanitizeRequestUrlForLogging(req.url),
         hasBody: !!body,
       });
 
@@ -411,16 +448,17 @@ export class RestApiRouter {
       'GET:/api/v1/logs': () =>
         this.handleGetLogs(req, res, requestId, searchParams),
       'GET:/api/v1/prompts': () =>
-        this.handlePromptsListRequest(req, res, requestId),
+        this.handlePromptsListRequest(req, res, requestId, searchParams),
       'POST:/api/v1/prompts/refresh': () =>
-        this.handlePromptsCacheRefresh(req, res, requestId),
+        this.handlePromptsCacheRefresh(req, res, requestId, body),
       'POST:/api/v1/prompts/:promptName': () =>
         this.handlePromptsGetRequest(
           req,
           res,
           requestId,
           params.promptName,
-          body
+          body,
+          searchParams
         ),
       'GET:/api/v1/visualize/:sessionId': () =>
         this.handleVisualize(
@@ -1805,17 +1843,85 @@ export class RestApiRouter {
   }
 
   /**
+   * Extract and validate the per-request `repo` override (PRD #581).
+   *
+   * Returns:
+   *   - { ok: true, override }    when no repo param is supplied, override is undefined.
+   *   - { ok: true, override }    when a syntactically valid override URL is supplied.
+   *   - { ok: false, message }    when the override fails validation (HTTP 400).
+   *
+   * The validation message is run through scrubCredentials so embedded tokens
+   * never reach the wire response.
+   */
+  private extractPromptsOverride(repoParam: unknown):
+    | {
+        ok: true;
+        override?: UserPromptsOverride;
+      }
+    | {
+        ok: false;
+        message: string;
+      } {
+    // Treat absent (null/undefined) as no override.
+    if (repoParam === undefined || repoParam === null) {
+      return { ok: true, override: undefined };
+    }
+    // The wire contract says `repo` is a string. Anything else (array,
+    // number, object, boolean) is a 400 — otherwise downstream code
+    // would crash to a 500.
+    if (typeof repoParam !== 'string') {
+      return {
+        ok: false,
+        message: `repo must be a string (got ${Array.isArray(repoParam) ? 'array' : typeof repoParam})`,
+      };
+    }
+    const trimmed = repoParam.trim();
+    if (!trimmed) {
+      return { ok: true, override: undefined };
+    }
+    const candidate: UserPromptsOverride = { repoUrl: trimmed };
+    try {
+      // Throws on invalid scheme / subPath / branch.
+      getUserPromptsConfigFromOverride(candidate);
+      return { ok: true, override: candidate };
+    } catch (error) {
+      const raw = error instanceof Error ? error.message : 'Invalid override';
+      return { ok: false, message: scrubCredentials(raw) };
+    }
+  }
+
+  /**
    * Handle prompts list requests
    */
   private async handlePromptsListRequest(
     req: IncomingMessage,
     res: ServerResponse,
-    requestId: string
+    requestId: string,
+    searchParams: URLSearchParams
   ): Promise<void> {
     try {
       this.logger.info('Processing prompts list request', { requestId });
 
-      const result = await handlePromptsListRequest({}, this.logger, requestId);
+      const overrideResult = this.extractPromptsOverride(
+        searchParams.get('repo')
+      );
+      if (!overrideResult.ok) {
+        await this.sendErrorResponse(
+          res,
+          requestId,
+          HttpStatus.BAD_REQUEST,
+          'VALIDATION_ERROR',
+          overrideResult.message
+        );
+        return;
+      }
+
+      const result = await handlePromptsListRequest(
+        {},
+        this.logger,
+        requestId,
+        overrideResult.override
+      );
 
       const response: RestApiResponse = {
         success: true,
@@ -1860,7 +1966,8 @@ export class RestApiRouter {
     res: ServerResponse,
     requestId: string,
     promptName: string,
-    body: unknown
+    body: unknown,
+    searchParams: URLSearchParams
   ): Promise<void> {
     try {
       this.logger.info('Processing prompt get request', {
@@ -1868,13 +1975,28 @@ export class RestApiRouter {
         promptName,
       });
 
+      const overrideResult = this.extractPromptsOverride(
+        searchParams.get('repo')
+      );
+      if (!overrideResult.ok) {
+        await this.sendErrorResponse(
+          res,
+          requestId,
+          HttpStatus.BAD_REQUEST,
+          'VALIDATION_ERROR',
+          overrideResult.message
+        );
+        return;
+      }
+
       const bodyObj = body as
         | { arguments?: Record<string, string> }
         | undefined;
       const result = await handlePromptsGetRequest(
         { name: promptName, arguments: bodyObj?.arguments },
         this.logger,
-        requestId
+        requestId,
+        overrideResult.override
       );
 
       const response: RestApiResponse = {
@@ -1923,22 +2045,42 @@ export class RestApiRouter {
   }
 
   /**
-   * Handle prompts cache refresh requests (PRD #386)
+   * Handle prompts cache refresh requests (PRD #386, extended PRD #581)
    */
   private async handlePromptsCacheRefresh(
     req: IncomingMessage,
     res: ServerResponse,
-    requestId: string
+    requestId: string,
+    body: unknown
   ): Promise<void> {
     try {
       this.logger.info('Processing prompts cache refresh request', {
         requestId,
       });
 
-      const prompts = await loadAllPrompts(this.logger, undefined, true);
+      // body.repo type is checked inside extractPromptsOverride (it accepts
+      // unknown and rejects non-string values with 400 — see F2).
+      const bodyObj = body as { repo?: unknown } | undefined;
+      const overrideResult = this.extractPromptsOverride(bodyObj?.repo);
+      if (!overrideResult.ok) {
+        await this.sendErrorResponse(
+          res,
+          requestId,
+          HttpStatus.BAD_REQUEST,
+          'VALIDATION_ERROR',
+          overrideResult.message
+        );
+        return;
+      }
 
-      const hasUserPromptsRepo = !!process.env.DOT_AI_USER_PROMPTS_REPO;
-      const source = hasUserPromptsRepo ? 'built-in+repository' : 'built-in';
+      const prompts = await loadAllPrompts(
+        this.logger,
+        undefined,
+        true,
+        overrideResult.override
+      );
+
+      const source = computePromptsSource(overrideResult.override);
 
       const response: RestApiResponse = {
         success: true,
@@ -2224,7 +2366,9 @@ export class RestApiRouter {
       let isFallbackResponse = false;
       try {
         if (result.status && result.status !== 'success') {
-          throw new Error(`AI visualization generation ${result.status}: ${result.finalMessage}`);
+          throw new Error(
+            `AI visualization generation ${result.status}: ${result.finalMessage}`
+          );
         }
         const toolsUsed = [
           ...new Set(result.toolCallsExecuted.map(tc => tc.tool)),
@@ -2363,7 +2507,12 @@ export class RestApiRouter {
         0
       );
 
-      this.logger.info('Listing sessions', { requestId, status, limit, offset });
+      this.logger.info('Listing sessions', {
+        requestId,
+        status,
+        limit,
+        offset,
+      });
 
       const sessionManager = new GenericSessionManager<Record<string, unknown>>(
         'rem'
@@ -2467,7 +2616,7 @@ export class RestApiRouter {
     const headers: Record<string, string> = {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
-      'Connection': 'keep-alive',
+      Connection: 'keep-alive',
     };
 
     if (this.config.enableCors) {

--- a/src/interfaces/rest-api.ts
+++ b/src/interfaces/rest-api.ts
@@ -76,12 +76,25 @@ import {
 } from '../core/rbac';
 
 /**
+ * Constant placeholder used when the request URL fails to parse and the
+ * caller would otherwise have to choose between logging a potentially
+ * credential-bearing query string or dropping the request log entirely. A
+ * stable string keeps log-grepping useful.
+ */
+export const UNPARSEABLE_QUERY_PLACEHOLDER = '?<redacted-unparseable>';
+
+/**
  * F3: req.url is logged on every request; with PRD #581 the query string may
  * carry `?repo=<user-supplied-url>` whose value can include credentials. This
  * helper rewrites the `repo` value to its credential-scrubbed form so the
- * raw token doesn't reach the log. Everything else is preserved verbatim. On
- * any parse failure the original string is returned (defensive — better to
- * log a slightly noisy URL than to drop the entire request log).
+ * raw token doesn't reach the log. Everything else is preserved verbatim.
+ *
+ * CodeRabbit Major B: on parse failure, we no longer return the input
+ * verbatim — an unparseable URL is more likely than a parseable one to hide
+ * a credential (a stray character may have broken the parse). Instead, keep
+ * the pathname (so the log still tells you which endpoint was hit) but
+ * REDACT the entire query string with a fixed placeholder. URLs without a
+ * '?' are pass-through (no risk).
  */
 export function sanitizeRequestUrlForLogging(
   url: string | undefined
@@ -98,7 +111,12 @@ export function sanitizeRequestUrlForLogging(
     // Return path + search only (drop the dummy base).
     return parsed.pathname + parsed.search + parsed.hash;
   } catch {
-    return url;
+    // F3/Major B: don't echo a potentially credential-bearing query string
+    // we couldn't parse. Keep the path (useful for log triage) and replace
+    // the rest with a constant marker.
+    const qIdx = url.indexOf('?');
+    if (qIdx === -1) return url;
+    return url.slice(0, qIdx) + UNPARSEABLE_QUERY_PLACEHOLDER;
   }
 }
 

--- a/src/tools/prompts.ts
+++ b/src/tools/prompts.ts
@@ -26,8 +26,8 @@ export interface PromptMetadata {
 }
 
 export interface PromptFile {
-  path: string;       // Relative path within skill folder (e.g., "create-worktree.sh")
-  content: string;    // Base64-encoded file content
+  path: string; // Relative path within skill folder (e.g., "create-worktree.sh")
+  content: string; // Base64-encoded file content
 }
 
 export interface Prompt {
@@ -242,16 +242,19 @@ export function mergePrompts(
 export async function loadAllPrompts(
   logger: Logger,
   baseDir?: string,
-  forceRefresh: boolean = false
+  forceRefresh: boolean = false,
+  override?: import('../core/user-prompts-loader.js').UserPromptsOverride
 ): Promise<Prompt[]> {
   // Load built-in prompts (synchronous)
   const builtInPrompts = loadBuiltInPrompts(logger, baseDir);
 
-  // Load user prompts from git repository (async, graceful failure)
+  // Load user prompts from git repository (async, graceful failure). When a
+  // per-request override is supplied (PRD #581), it replaces the env-var
+  // configured repo for this single call.
   let userPrompts: Prompt[] = [];
   try {
     const { loadUserPrompts } = await import('../core/user-prompts-loader.js');
-    userPrompts = await loadUserPrompts(logger, forceRefresh);
+    userPrompts = await loadUserPrompts(logger, forceRefresh, override);
   } catch (error) {
     logger.debug('User prompts loader not available or failed', {
       error: error instanceof Error ? error.message : 'Unknown error',
@@ -282,22 +285,30 @@ interface PromptsListResponse {
     description: string;
     arguments?: PromptArgument[];
   }>;
+  source: string;
 }
 
 /**
- * Handle prompts/list MCP request
+ * Handle prompts/list MCP request.
+ *
+ * The optional `override` parameter (PRD #581) is REST-only; MCP callers always
+ * pass undefined since there's no natural way for MCP to express a per-request
+ * repo override.
  */
 export async function handlePromptsListRequest(
   args: PromptsListArgs | undefined,
   logger: Logger,
-  requestId: string
+  requestId: string,
+  override?: import('../core/user-prompts-loader.js').UserPromptsOverride
 ): Promise<PromptsListResponse> {
   try {
     logger.info('Processing prompts/list request', { requestId });
 
     const allPrompts = await loadAllPrompts(
       logger,
-      process.env.NODE_ENV === 'test' ? args?.baseDir : undefined
+      process.env.NODE_ENV === 'test' ? args?.baseDir : undefined,
+      false,
+      override
     );
 
     // Filter out file-dependent skills when requested (MCP clients can't deliver files)
@@ -326,8 +337,12 @@ export async function handlePromptsListRequest(
       promptCount: promptList.length,
     });
 
+    const { computePromptsSource } =
+      await import('../core/user-prompts-loader.js');
+
     return {
       prompts: promptList,
+      source: computePromptsSource(override),
     };
   } catch (error) {
     logger.error('Prompts list request failed', error as Error);
@@ -356,15 +371,21 @@ interface PromptsGetResponse {
   description?: string;
   messages: Array<{ role: string; content: { type: string; text: string } }>;
   files?: PromptFile[];
+  source: string;
 }
 
 /**
- * Handle prompts/get MCP request
+ * Handle prompts/get MCP request.
+ *
+ * The optional `override` parameter (PRD #581) is REST-only; MCP callers always
+ * pass undefined since there's no natural way for MCP to express a per-request
+ * repo override.
  */
 export async function handlePromptsGetRequest(
   args: PromptsGetArgs,
   logger: Logger,
-  requestId: string
+  requestId: string,
+  override?: import('../core/user-prompts-loader.js').UserPromptsOverride
 ): Promise<PromptsGetResponse> {
   try {
     logger.info('Processing prompts/get request', {
@@ -378,7 +399,9 @@ export async function handlePromptsGetRequest(
 
     const prompts = await loadAllPrompts(
       logger,
-      process.env.NODE_ENV === 'test' ? args?.baseDir : undefined
+      process.env.NODE_ENV === 'test' ? args?.baseDir : undefined,
+      false,
+      override
     );
     const prompt = prompts.find(p => p.name === args.name);
 
@@ -435,6 +458,9 @@ export async function handlePromptsGetRequest(
       argumentsProvided: Object.keys(providedArgs).length,
     });
 
+    const { computePromptsSource } =
+      await import('../core/user-prompts-loader.js');
+
     // Convert to MCP prompts/get response format
     const response: PromptsGetResponse = {
       description: prompt.description,
@@ -447,6 +473,7 @@ export async function handlePromptsGetRequest(
           },
         },
       ],
+      source: computePromptsSource(override),
     };
 
     if (prompt.files && prompt.files.length > 0) {

--- a/tests/integration/tools/prompts.test.ts
+++ b/tests/integration/tools/prompts.test.ts
@@ -23,33 +23,84 @@ describe.concurrent('Prompts Integration', () => {
 
   // Exact list of all built-in prompts with their metadata
   const expectedBuiltInPrompts = [
-    { name: 'generate-cicd', description: 'Generate intelligent CI/CD workflows through interactive conversation by analyzing repository structure and user preferences' },
-    { name: 'generate-dockerfile', description: 'Generate production-ready, secure, multi-stage Dockerfile and .dockerignore for any project' },
-    { name: 'prd-close', description: 'Close a PRD that is already implemented or no longer needed' },
-    { name: 'prd-create', description: 'Create documentation-first PRDs that guide development through user-facing content' },
-    { name: 'prd-done', description: 'Complete PRD implementation workflow - create branch, push changes, create PR, merge, and close issue' },
+    {
+      name: 'generate-cicd',
+      description:
+        'Generate intelligent CI/CD workflows through interactive conversation by analyzing repository structure and user preferences',
+    },
+    {
+      name: 'generate-dockerfile',
+      description:
+        'Generate production-ready, secure, multi-stage Dockerfile and .dockerignore for any project',
+    },
+    {
+      name: 'prd-close',
+      description:
+        'Close a PRD that is already implemented or no longer needed',
+    },
+    {
+      name: 'prd-create',
+      description:
+        'Create documentation-first PRDs that guide development through user-facing content',
+    },
+    {
+      name: 'prd-done',
+      description:
+        'Complete PRD implementation workflow - create branch, push changes, create PR, merge, and close issue',
+    },
     {
       name: 'prd-full',
-      description: 'Run a PRD end-to-end autonomously — start, iterate until done, then create a PR. Stops after PR creation for manual review.',
+      description:
+        'Run a PRD end-to-end autonomously — start, iterate until done, then create a PR. Stops after PR creation for manual review.',
       arguments: [
-        { name: 'prdNumber', description: 'PRD number to implement (e.g., 306). Required — no auto-detection.', required: true },
-        { name: 'mode', description: 'Isolation strategy for this PRD\'s work. Must be `branch` or `worktree`. Pre-answers the branch-vs-worktree decision in `/prd-start`.', required: true }
+        {
+          name: 'prdNumber',
+          description:
+            'PRD number to implement (e.g., 306). Required — no auto-detection.',
+          required: true,
+        },
+        {
+          name: 'mode',
+          description:
+            "Isolation strategy for this PRD's work. Must be `branch` or `worktree`. Pre-answers the branch-vs-worktree decision in `/prd-start`.",
+          required: true,
+        },
       ],
       // prd-full has required arguments — the Prompts Get test must supply
       // them or the server returns success: false.
-      testArgs: { prdNumber: '306', mode: 'branch' }
+      testArgs: { prdNumber: '306', mode: 'branch' },
     },
-    { name: 'prd-next', description: 'Analyze existing PRD to identify and recommend the single highest-priority task to work on next' },
+    {
+      name: 'prd-next',
+      description:
+        'Analyze existing PRD to identify and recommend the single highest-priority task to work on next',
+    },
     {
       name: 'prd-start',
       description: 'Start working on a PRD implementation',
       arguments: [
-        { name: 'prdNumber', description: 'PRD number to start working on (e.g., 306)', required: false }
-      ]
+        {
+          name: 'prdNumber',
+          description: 'PRD number to start working on (e.g., 306)',
+          required: false,
+        },
+      ],
     },
-    { name: 'prd-update-decisions', description: 'Update PRD based on design decisions and strategic changes made during conversations' },
-    { name: 'prd-update-progress', description: 'Update PRD progress based on git commits and code changes, enhanced by conversation context' },
-    { name: 'prds-get', description: 'Fetch all open GitHub issues from this project that have the \'PRD\' label' },
+    {
+      name: 'prd-update-decisions',
+      description:
+        'Update PRD based on design decisions and strategic changes made during conversations',
+    },
+    {
+      name: 'prd-update-progress',
+      description:
+        'Update PRD progress based on git commits and code changes, enhanced by conversation context',
+    },
+    {
+      name: 'prds-get',
+      description:
+        "Fetch all open GitHub issues from this project that have the 'PRD' label",
+    },
   ];
 
   // User prompts loaded from git repository (user-prompts/ directory)
@@ -59,12 +110,29 @@ describe.concurrent('Prompts Integration', () => {
       name: 'eval-run',
       description: 'Run AI Model Evaluations',
       arguments: [
-        { name: 'toolType', description: 'Evaluation type (capabilities, policies, patterns, remediation, recommendation)', required: false },
-        { name: 'models', description: 'Comma-separated list of models (sonnet, gpt, gemini, gemini-flash, grok)', required: false }
-      ]
+        {
+          name: 'toolType',
+          description:
+            'Evaluation type (capabilities, policies, patterns, remediation, recommendation)',
+          required: false,
+        },
+        {
+          name: 'models',
+          description:
+            'Comma-separated list of models (sonnet, gpt, gemini, gemini-flash, grok)',
+          required: false,
+        },
+      ],
     },
-    { name: 'eval-update-model-metadata', description: 'Update Model Metadata Command' },
-    { name: 'test-skill', description: 'Test skill for folder-based skills integration tests', expectedFiles: ['helper.sh'] },
+    {
+      name: 'eval-update-model-metadata',
+      description: 'Update Model Metadata Command',
+    },
+    {
+      name: 'test-skill',
+      description: 'Test skill for folder-based skills integration tests',
+      expectedFiles: ['helper.sh'],
+    },
   ];
 
   // Combined list of all prompts (built-in + user)
@@ -93,16 +161,19 @@ describe.concurrent('Prompts Integration', () => {
         success: true,
         data: {
           prompts: expect.arrayContaining(
-            expectedPrompts.map(({ expectedFiles: _e, testArgs: _t, ...rest }) =>
-              expect.objectContaining(rest)
+            expectedPrompts.map(
+              ({ expectedFiles: _e, testArgs: _t, ...rest }) =>
+                expect.objectContaining(rest)
             )
           ),
         },
         meta: {
-          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          timestamp: expect.stringMatching(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+          ),
           requestId: expect.stringMatching(/^rest_\d+_\d+$/),
-          version: 'v1'
-        }
+          version: 'v1',
+        },
       };
 
       expect(response).toMatchObject(expectedListResponse);
@@ -112,71 +183,85 @@ describe.concurrent('Prompts Integration', () => {
 
   describe('Prompts Get', () => {
     // Test each prompt individually (including folder-based skills with files)
-    test.each(expectedPrompts)('should return prompt content for $name', async ({ name, description, expectedFiles, testArgs }) => {
-      const response = await integrationTest.httpClient.post(
-        `/api/v1/prompts/${name}`,
-        testArgs ? { arguments: testArgs } : {}
-      );
-
-      const expectedGetResponse = {
-        success: true,
-        data: {
-          description: description,
-          messages: [
-            {
-              role: 'user',
-              content: {
-                type: 'text',
-                text: expect.any(String)
-              }
-            }
-          ]
-        },
-        meta: {
-          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
-          requestId: expect.stringMatching(/^rest_\d+_\d+$/),
-          version: 'v1'
-        }
-      };
-
-      expect(response).toMatchObject(expectedGetResponse);
-      // Verify content is non-empty
-      expect(response.data.messages[0].content.text.length).toBeGreaterThan(100);
-
-      // Verify files field for folder-based skills vs flat prompts
-      if (expectedFiles) {
-        expect(response.data).toMatchObject({
-          files: expectedFiles.map((filePath: string) => ({
-            path: filePath,
-            content: expect.any(String),
-          })),
-        });
-        // Verify base64 content decodes to non-empty string
-        for (const file of response.data.files) {
-          const decoded = Buffer.from(file.content, 'base64').toString('utf-8');
-          expect(decoded.length).toBeGreaterThan(0);
-        }
-      } else {
-        expect(response.data).toMatchObject(
-          expect.not.objectContaining({ files: expect.anything() })
+    test.each(expectedPrompts)(
+      'should return prompt content for $name',
+      async ({ name, description, expectedFiles, testArgs }) => {
+        const response = await integrationTest.httpClient.post(
+          `/api/v1/prompts/${name}`,
+          testArgs ? { arguments: testArgs } : {}
         );
+
+        const expectedGetResponse = {
+          success: true,
+          data: {
+            description: description,
+            messages: [
+              {
+                role: 'user',
+                content: {
+                  type: 'text',
+                  text: expect.any(String),
+                },
+              },
+            ],
+          },
+          meta: {
+            timestamp: expect.stringMatching(
+              /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+            ),
+            requestId: expect.stringMatching(/^rest_\d+_\d+$/),
+            version: 'v1',
+          },
+        };
+
+        expect(response).toMatchObject(expectedGetResponse);
+        // Verify content is non-empty
+        expect(response.data.messages[0].content.text.length).toBeGreaterThan(
+          100
+        );
+
+        // Verify files field for folder-based skills vs flat prompts
+        if (expectedFiles) {
+          expect(response.data).toMatchObject({
+            files: expectedFiles.map((filePath: string) => ({
+              path: filePath,
+              content: expect.any(String),
+            })),
+          });
+          // Verify base64 content decodes to non-empty string
+          for (const file of response.data.files) {
+            const decoded = Buffer.from(file.content, 'base64').toString(
+              'utf-8'
+            );
+            expect(decoded.length).toBeGreaterThan(0);
+          }
+        } else {
+          expect(response.data).toMatchObject(
+            expect.not.objectContaining({ files: expect.anything() })
+          );
+        }
       }
-    });
+    );
 
     test('should return error for non-existent prompt', async () => {
-      const response = await integrationTest.httpClient.post('/api/v1/prompts/non-existent-prompt', {});
+      const response = await integrationTest.httpClient.post(
+        '/api/v1/prompts/non-existent-prompt',
+        {}
+      );
 
       const expectedErrorResponse = {
         success: false,
         error: {
           code: 'VALIDATION_ERROR',
-          message: 'Prompt not found: non-existent-prompt'
+          message: 'Prompt not found: non-existent-prompt',
         },
         meta: {
-          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          timestamp: expect.stringMatching(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+          ),
           requestId: expect.stringMatching(/^rest_\d+_\d+$/),
-          version: 'v1'
-        }
+          version: 'v1',
+        },
       };
 
       expect(response).toMatchObject(expectedErrorResponse);
@@ -187,15 +272,24 @@ describe.concurrent('Prompts Integration', () => {
     test('should return prd-start with arguments metadata in list', async () => {
       const response = await integrationTest.httpClient.get('/api/v1/prompts');
 
-      const prdStartPrompt = response.data.prompts.find((p: { name: string }) => p.name === 'prd-start');
+      const prdStartPrompt = response.data.prompts.find(
+        (p: { name: string }) => p.name === 'prd-start'
+      );
       expect(prdStartPrompt).toBeDefined();
       expect(prdStartPrompt.arguments).toEqual([
-        { name: 'prdNumber', description: 'PRD number to start working on (e.g., 306)', required: false }
+        {
+          name: 'prdNumber',
+          description: 'PRD number to start working on (e.g., 306)',
+          required: false,
+        },
       ]);
     });
 
     test('should return prd-start content without argument (placeholder remains)', async () => {
-      const response = await integrationTest.httpClient.post('/api/v1/prompts/prd-start', {});
+      const response = await integrationTest.httpClient.post(
+        '/api/v1/prompts/prd-start',
+        {}
+      );
 
       expect(response.success).toBe(true);
       // Without argument, the placeholder should remain in the content
@@ -203,13 +297,18 @@ describe.concurrent('Prompts Integration', () => {
     });
 
     test('should substitute argument when provided to prd-start', async () => {
-      const response = await integrationTest.httpClient.post('/api/v1/prompts/prd-start', {
-        arguments: { prdNumber: '306' }
-      });
+      const response = await integrationTest.httpClient.post(
+        '/api/v1/prompts/prd-start',
+        {
+          arguments: { prdNumber: '306' },
+        }
+      );
 
       expect(response.success).toBe(true);
       // With argument, the placeholder should be substituted
-      expect(response.data.messages[0].content.text).not.toContain('{{prdNumber}}');
+      expect(response.data.messages[0].content.text).not.toContain(
+        '{{prdNumber}}'
+      );
       expect(response.data.messages[0].content.text).toContain('306');
     });
   });
@@ -279,7 +378,8 @@ describe.concurrent('Prompts Integration', () => {
 
       try {
         // Step 1: Record initial prompt count
-        const initialList = await integrationTest.httpClient.get('/api/v1/prompts');
+        const initialList =
+          await integrationTest.httpClient.get('/api/v1/prompts');
         expect(initialList).toMatchObject({ success: true });
         const initialCount = initialList.data.prompts.length;
 
@@ -287,27 +387,37 @@ describe.concurrent('Prompts Integration', () => {
         fileSha = await createFileInRepo();
 
         // Step 3: Verify list still returns cached (old) count
-        const cachedList = await integrationTest.httpClient.get('/api/v1/prompts');
+        const cachedList =
+          await integrationTest.httpClient.get('/api/v1/prompts');
         expect(cachedList.data.prompts.length).toBe(initialCount);
 
         // Step 4: Call refresh
-        const refreshResponse = await integrationTest.httpClient.post('/api/v1/prompts/refresh', {});
+        const refreshResponse = await integrationTest.httpClient.post(
+          '/api/v1/prompts/refresh',
+          {}
+        );
         expect(refreshResponse).toMatchObject({
           success: true,
           data: {
             refreshed: true,
             promptsLoaded: expect.any(Number),
-            source: expect.stringMatching(/^built-in(\+repository)?$/),
+            // PRD #581: source is now the env-var URL when configured, or
+            // "built-in" when no env-var repo is set. The integration test
+            // env always sets DOT_AI_USER_PROMPTS_REPO, so we expect a URL.
+            source: expect.stringMatching(/^https?:\/\/|^built-in$/),
           },
           meta: {
-            timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+            timestamp: expect.stringMatching(
+              /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+            ),
             requestId: expect.stringMatching(/^rest_\d+_\d+$/),
-            version: 'v1'
-          }
+            version: 'v1',
+          },
         });
 
         // Step 5: Verify list now includes the new prompt
-        const refreshedList = await integrationTest.httpClient.get('/api/v1/prompts');
+        const refreshedList =
+          await integrationTest.httpClient.get('/api/v1/prompts');
         expect(refreshedList.data.prompts.length).toBe(initialCount + 1);
         const newPrompt = refreshedList.data.prompts.find(
           (p: { name: string }) => p.name === testPromptName
@@ -327,7 +437,9 @@ describe.concurrent('Prompts Integration', () => {
     }, 300000);
 
     test('should reject GET method for refresh endpoint', async () => {
-      const response = await integrationTest.httpClient.get('/api/v1/prompts/refresh');
+      const response = await integrationTest.httpClient.get(
+        '/api/v1/prompts/refresh'
+      );
 
       expect(response).toMatchObject({
         success: false,
@@ -336,17 +448,22 @@ describe.concurrent('Prompts Integration', () => {
           message: expect.stringContaining('Only POST method allowed'),
         },
         meta: {
-          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          timestamp: expect.stringMatching(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+          ),
           requestId: expect.stringMatching(/^rest_\d+_\d+$/),
-          version: 'v1'
-        }
+          version: 'v1',
+        },
       });
     });
   });
 
   describe('HTTP Method Validation', () => {
     test('should reject POST for prompts list endpoint', async () => {
-      const response = await integrationTest.httpClient.post('/api/v1/prompts', {});
+      const response = await integrationTest.httpClient.post(
+        '/api/v1/prompts',
+        {}
+      );
 
       const expectedErrorResponse = {
         success: false,
@@ -355,17 +472,21 @@ describe.concurrent('Prompts Integration', () => {
           message: expect.stringContaining('Only GET method allowed'),
         },
         meta: {
-          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          timestamp: expect.stringMatching(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+          ),
           requestId: expect.stringMatching(/^rest_\d+_\d+$/),
-          version: 'v1'
-        }
+          version: 'v1',
+        },
       };
 
       expect(response).toMatchObject(expectedErrorResponse);
     });
 
     test('should reject GET for prompt get endpoint', async () => {
-      const response = await integrationTest.httpClient.get('/api/v1/prompts/generate-dockerfile');
+      const response = await integrationTest.httpClient.get(
+        '/api/v1/prompts/generate-dockerfile'
+      );
 
       const expectedErrorResponse = {
         success: false,
@@ -374,13 +495,148 @@ describe.concurrent('Prompts Integration', () => {
           message: expect.stringContaining('Only POST method allowed'),
         },
         meta: {
-          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          timestamp: expect.stringMatching(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+          ),
           requestId: expect.stringMatching(/^rest_\d+_\d+$/),
-          version: 'v1'
-        }
+          version: 'v1',
+        },
       };
 
       expect(response).toMatchObject(expectedErrorResponse);
+    });
+  });
+
+  describe('Per-request override (PRD #581)', () => {
+    // The integration test infra sets DOT_AI_USER_PROMPTS_REPO and
+    // DOT_AI_USER_PROMPTS_PATH=user-prompts. A REST override only carries
+    // repoUrl (the wire contract for M2 — branch/subPath stay at defaults),
+    // so any happy-path override invalidates the loader cache via the
+    // (repoUrl, branch, subPath) cache key. That re-clone races against the
+    // 'Prompts Cache Refresh' test in this file AND against any other
+    // integration file that touches /api/v1/prompts — vitest's fork pool
+    // runs files in parallel against the same deployed server, so even a
+    // separate non-concurrent file (PRD #581 F5) races. The happy-path
+    // override response shape (source echo, override threading) is
+    // therefore covered by:
+    //   - the unit-level loader tests in tests/unit/core/user-prompts-loader.test.ts
+    //     (which exercise the full override flow with the git boundary
+    //     mocked, so cache state is process-local and isolated)
+    //   - the unit-level computePromptsSource tests in
+    //     tests/unit/core/user-prompts-source.test.ts (which pin the wire
+    //     contract for the `source` field — including credential scrubbing)
+    //   - the mock-server unit tests in tests/unit/mock-server/fixtures.test.ts
+    //     (which prove the wire contract end-to-end against the fixture
+    //     server the CLI tests against)
+    //
+    // What we CAN test at the REST integration level without touching the
+    // user-prompts cache are the validation paths (rejected before any clone)
+    // and the no-override source value. Those are exercised below.
+
+    test('GET /api/v1/prompts without ?repo returns source from env-var config', async () => {
+      const response = await integrationTest.httpClient.get('/api/v1/prompts');
+      expect(response).toMatchObject({
+        success: true,
+        data: {
+          prompts: expect.any(Array),
+          // Real server sets DOT_AI_USER_PROMPTS_REPO so source is a URL.
+          source: expect.stringMatching(/^https?:\/\//),
+        },
+      });
+    });
+
+    test('GET /api/v1/prompts?repo=ssh://... returns 400 with credential-safe message', async () => {
+      const response = await integrationTest.httpClient.get(
+        `/api/v1/prompts?repo=${encodeURIComponent('ssh://git@github.com/example/repo.git')}`
+      );
+      expect(response).toMatchObject({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: expect.stringContaining('scheme'),
+        },
+      });
+    });
+
+    test('GET /api/v1/prompts?repo=<url-with-token-and-bad-scheme> scrubs token from validation error', async () => {
+      const secret = 'rest_test_secret_token_xyz';
+      // Bad scheme so we hit the 400 path; the response must not echo the
+      // secret embedded in the URL.
+      const credUrl = `ssh://user:${secret}@github.com/example/repo.git`;
+      const response = await integrationTest.httpClient.get(
+        `/api/v1/prompts?repo=${encodeURIComponent(credUrl)}`
+      );
+      expect(response).toMatchObject({ success: false });
+      expect(JSON.stringify(response)).not.toContain(secret);
+    });
+
+    test('POST /api/v1/prompts/refresh with body.repo=ssh://... returns 400', async () => {
+      const response = await integrationTest.httpClient.post(
+        '/api/v1/prompts/refresh',
+        { repo: 'ssh://git@github.com/example/repo.git' }
+      );
+      expect(response).toMatchObject({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: expect.stringContaining('scheme'),
+        },
+      });
+    });
+
+    // F2: type-checking guards against the server crashing to 500 on a
+    // malformed body. `repo` MUST be a string per the wire contract.
+    test('POST /api/v1/prompts/refresh with body.repo as array returns 400 (not 500)', async () => {
+      const response = await integrationTest.httpClient.post(
+        '/api/v1/prompts/refresh',
+        { repo: ['https://github.com/a/b.git', 'https://github.com/c/d.git'] }
+      );
+      expect(response).toMatchObject({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: expect.stringContaining('repo must be a string'),
+        },
+      });
+    });
+
+    test('POST /api/v1/prompts/refresh with body.repo as number returns 400 (not 500)', async () => {
+      const response = await integrationTest.httpClient.post(
+        '/api/v1/prompts/refresh',
+        { repo: 42 }
+      );
+      expect(response).toMatchObject({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: expect.stringContaining('repo must be a string'),
+        },
+      });
+    });
+
+    test('POST /api/v1/prompts/:name?repo=ssh://... returns 400', async () => {
+      const response = await integrationTest.httpClient.post(
+        `/api/v1/prompts/prd-create?repo=${encodeURIComponent('ssh://git@github.com/example/repo.git')}`,
+        {}
+      );
+      expect(response).toMatchObject({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: expect.stringContaining('scheme'),
+        },
+      });
+    });
+
+    test('POST /api/v1/prompts/:name?repo=<url-with-token-and-bad-scheme> scrubs token from response', async () => {
+      const secret = 'name_test_secret_xyz';
+      const credUrl = `ssh://user:${secret}@github.com/example/repo.git`;
+      const response = await integrationTest.httpClient.post(
+        `/api/v1/prompts/prd-create?repo=${encodeURIComponent(credUrl)}`,
+        {}
+      );
+      expect(response).toMatchObject({ success: false });
+      expect(JSON.stringify(response)).not.toContain(secret);
     });
   });
 });

--- a/tests/unit/core/user-prompts-loader.test.ts
+++ b/tests/unit/core/user-prompts-loader.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Unit Tests: User Prompts Loader (Override)
+ *
+ * Exercises the per-request override added in PRD #581 milestone 1 plus the
+ * validation/scrubbing follow-ups. Verifies:
+ *   - Omitted/undefined `override` arg keeps existing behavior (and the second
+ *     call serves from cache, proving the param doesn't perturb caching)
+ *   - A supplied override fetches from the override repo and ignores
+ *     `DOT_AI_USER_PROMPTS_REPO`
+ *   - Cache is invalidated when any of (repoUrl, branch, subPath) changes
+ *   - Consecutive calls with the same override repoUrl serve from cache
+ *   - Override input validation rejects bad scheme / traversal / branch
+ *   - A failing override clone returns empty without corrupting the env-var
+ *     cache state, and a subsequent no-override call recovers
+ *   - Credentials in an override URL are scrubbed from all log output, including
+ *     errors propagated through the outer catch
+ *
+ * Network IO is mocked at the `cloneRepo`/`pullRepo` boundary so tests remain
+ * deterministic. The loader logic, cache invalidation, scrubCredentials, and
+ * sanitizeUrlForLogging all still run end-to-end.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  vi,
+} from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+vi.mock('../../../src/core/git-utils.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/core/git-utils.js')
+  >('../../../src/core/git-utils.js');
+  return {
+    ...actual,
+    cloneRepo: vi.fn(),
+    pullRepo: vi.fn(),
+  };
+});
+
+import { cloneRepo } from '../../../src/core/git-utils.js';
+import {
+  loadUserPrompts,
+  clearUserPromptsCache,
+  getUserPromptsCacheState,
+} from '../../../src/core/user-prompts-loader.js';
+import type { Logger } from '../../../src/core/error-handling.js';
+
+const ENV_REPO = 'https://github.com/example-org/env-repo.git';
+const OVERRIDE_REPO = 'https://github.com/example-org/override-repo.git';
+
+interface CapturedCall {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  data?: Record<string, unknown>;
+  errorMessage?: string;
+}
+
+function makeCapturingLogger(): { logger: Logger; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const logger: Logger = {
+    debug: (message, data) => calls.push({ level: 'debug', message, data }),
+    info: (message, data) => calls.push({ level: 'info', message, data }),
+    warn: (message, data) => calls.push({ level: 'warn', message, data }),
+    error: (message, error, data) =>
+      calls.push({
+        level: 'error',
+        message,
+        data,
+        errorMessage: error?.message,
+      }),
+  };
+  return { logger, calls };
+}
+
+// Mock that produces a tiny but valid prompts directory at targetDir, so the
+// loader's scan + parse pipeline runs to completion.
+function makeSuccessfulClone() {
+  return vi.fn(async (_url: string, targetDir: string) => {
+    fs.mkdirSync(targetDir, { recursive: true });
+    const promptBody = [
+      '---',
+      'name: prd-581-test',
+      'description: Test prompt for PRD 581 loader override',
+      '---',
+      '',
+      'Body content for the test prompt.',
+    ].join('\n');
+    fs.writeFileSync(path.join(targetDir, 'prd-581-test.md'), promptBody);
+    return { localPath: targetDir, branch: 'main' };
+  });
+}
+
+function makeFailingClone(message: string) {
+  return vi.fn(async () => {
+    throw new Error(message);
+  });
+}
+
+describe('User Prompts Loader Override', () => {
+  const savedEnv = {
+    repo: process.env.DOT_AI_USER_PROMPTS_REPO,
+    repoPath: process.env.DOT_AI_USER_PROMPTS_PATH,
+    branch: process.env.DOT_AI_USER_PROMPTS_BRANCH,
+    ttl: process.env.DOT_AI_USER_PROMPTS_CACHE_TTL,
+    token: process.env.DOT_AI_GIT_TOKEN,
+  };
+
+  beforeAll(() => {
+    // One-time guard: confirm the git-utils mock applied — if it didn't, every
+    // test would silently hit real network. Cheap, prevents confusing failures.
+    expect(vi.isMockFunction(cloneRepo)).toBe(true);
+  });
+
+  beforeEach(() => {
+    clearUserPromptsCache();
+    delete process.env.DOT_AI_USER_PROMPTS_REPO;
+    delete process.env.DOT_AI_USER_PROMPTS_PATH;
+    delete process.env.DOT_AI_USER_PROMPTS_BRANCH;
+    delete process.env.DOT_AI_USER_PROMPTS_CACHE_TTL;
+    delete process.env.DOT_AI_GIT_TOKEN;
+    vi.mocked(cloneRepo).mockReset();
+    vi.mocked(cloneRepo).mockImplementation(makeSuccessfulClone());
+  });
+
+  afterAll(() => {
+    clearUserPromptsCache();
+    if (savedEnv.repo !== undefined)
+      process.env.DOT_AI_USER_PROMPTS_REPO = savedEnv.repo;
+    if (savedEnv.repoPath !== undefined)
+      process.env.DOT_AI_USER_PROMPTS_PATH = savedEnv.repoPath;
+    if (savedEnv.branch !== undefined)
+      process.env.DOT_AI_USER_PROMPTS_BRANCH = savedEnv.branch;
+    if (savedEnv.ttl !== undefined)
+      process.env.DOT_AI_USER_PROMPTS_CACHE_TTL = savedEnv.ttl;
+    if (savedEnv.token !== undefined)
+      process.env.DOT_AI_GIT_TOKEN = savedEnv.token;
+  });
+
+  describe('Behavior parity (no override vs undefined override)', () => {
+    test('undefined override is byte-identical to no override and second call serves from cache', async () => {
+      process.env.DOT_AI_USER_PROMPTS_REPO = ENV_REPO;
+
+      const a = makeCapturingLogger();
+      const promptsA = await loadUserPrompts(a.logger);
+
+      const b = makeCapturingLogger();
+      const promptsB = await loadUserPrompts(b.logger, false, undefined);
+
+      expect(promptsA).toEqual(promptsB);
+      // The second call must NOT have re-cloned.
+      expect(cloneRepo).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(cloneRepo).mock.calls[0][0]).toBe(ENV_REPO);
+      // The second logger should have observed the cache-hit debug line, not
+      // a clone line — proving the cache path was taken.
+      expect(
+        b.calls.some(c => c.message === 'Using cached user prompts repository')
+      ).toBe(true);
+      expect(
+        b.calls.some(c => c.message === 'Cloning user prompts repository')
+      ).toBe(false);
+    });
+  });
+
+  describe('Override behavior', () => {
+    test('override fetches from override repo and ignores DOT_AI_USER_PROMPTS_REPO', async () => {
+      process.env.DOT_AI_USER_PROMPTS_REPO = ENV_REPO;
+
+      const { logger } = makeCapturingLogger();
+      const prompts = await loadUserPrompts(logger, false, {
+        repoUrl: OVERRIDE_REPO,
+      });
+
+      expect(cloneRepo).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(cloneRepo).mock.calls[0][0]).toBe(OVERRIDE_REPO);
+      expect(getUserPromptsCacheState()).toMatchObject({
+        repoUrl: OVERRIDE_REPO,
+        branch: 'main',
+        subPath: '',
+      });
+      expect(prompts).toMatchObject([
+        {
+          name: 'prd-581-test',
+          description: 'Test prompt for PRD 581 loader override',
+        },
+      ]);
+    });
+
+    test('two consecutive calls with the same override repo serve the second from cache', async () => {
+      await loadUserPrompts(makeCapturingLogger().logger, false, {
+        repoUrl: OVERRIDE_REPO,
+      });
+      const second = makeCapturingLogger();
+      const result = await loadUserPrompts(second.logger, false, {
+        repoUrl: OVERRIDE_REPO,
+      });
+
+      expect(cloneRepo).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject([{ name: 'prd-581-test' }]);
+      expect(
+        second.calls.some(
+          c => c.message === 'Using cached user prompts repository'
+        )
+      ).toBe(true);
+      expect(
+        second.calls.some(c => c.message === 'Cloning user prompts repository')
+      ).toBe(false);
+    });
+
+    test('different branch on the same repoUrl forces a fresh clone', async () => {
+      await loadUserPrompts(makeCapturingLogger().logger, false, {
+        repoUrl: OVERRIDE_REPO,
+        branch: 'main',
+      });
+      expect(cloneRepo).toHaveBeenCalledTimes(1);
+
+      const second = makeCapturingLogger();
+      await loadUserPrompts(second.logger, false, {
+        repoUrl: OVERRIDE_REPO,
+        branch: 'release-1.0',
+      });
+
+      expect(cloneRepo).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(cloneRepo).mock.calls[1][2]).toMatchObject({
+        branch: 'release-1.0',
+      });
+      expect(getUserPromptsCacheState()).toMatchObject({
+        repoUrl: OVERRIDE_REPO,
+        branch: 'release-1.0',
+      });
+    });
+  });
+
+  describe('Override input validation', () => {
+    test.each([
+      'file:///etc/passwd',
+      'ssh://git@github.com/example/repo.git',
+      'git://github.com/example/repo.git',
+    ])('rejects non-http(s) scheme %s', async credUrl => {
+      const { logger, calls } = makeCapturingLogger();
+      const result = await loadUserPrompts(logger, false, {
+        repoUrl: credUrl,
+      });
+
+      expect(result).toEqual([]);
+      expect(cloneRepo).not.toHaveBeenCalled();
+      expect(calls.some(c => c.level === 'error')).toBe(true);
+    });
+
+    test('rejects unparseable repoUrl', async () => {
+      const result = await loadUserPrompts(
+        makeCapturingLogger().logger,
+        false,
+        {
+          repoUrl: 'not a url at all',
+        }
+      );
+      expect(result).toEqual([]);
+      expect(cloneRepo).not.toHaveBeenCalled();
+    });
+
+    test.each(['../etc', 'a/../../escape', '/absolute/path'])(
+      'rejects unsafe subPath %s',
+      async subPath => {
+        const result = await loadUserPrompts(
+          makeCapturingLogger().logger,
+          false,
+          {
+            repoUrl: OVERRIDE_REPO,
+            subPath,
+          }
+        );
+        expect(result).toEqual([]);
+        expect(cloneRepo).not.toHaveBeenCalled();
+      }
+    );
+
+    test('rejects subPath containing a null byte', async () => {
+      const result = await loadUserPrompts(
+        makeCapturingLogger().logger,
+        false,
+        {
+          repoUrl: OVERRIDE_REPO,
+          subPath: 'safe/\0bad',
+        }
+      );
+      expect(result).toEqual([]);
+      expect(cloneRepo).not.toHaveBeenCalled();
+    });
+
+    test.each(['feature; rm -rf /', 'foo$(whoami)', 'name with spaces'])(
+      'rejects invalid branch %s',
+      async branch => {
+        const result = await loadUserPrompts(
+          makeCapturingLogger().logger,
+          false,
+          {
+            repoUrl: OVERRIDE_REPO,
+            branch,
+          }
+        );
+        expect(result).toEqual([]);
+        expect(cloneRepo).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('Failure isolation', () => {
+    test('malformed override does not corrupt env-var cache; next no-override call succeeds', async () => {
+      process.env.DOT_AI_USER_PROMPTS_REPO = ENV_REPO;
+
+      // 1. Populate cache from env-var.
+      const initialLogger = makeCapturingLogger();
+      const initial = await loadUserPrompts(initialLogger.logger);
+      expect(initial.length).toBeGreaterThan(0);
+      expect(getUserPromptsCacheState()).toMatchObject({ repoUrl: ENV_REPO });
+
+      // 2. Override with a URL that's structurally valid but unreachable; the
+      //    cloneRepo mock simulates the failure.
+      vi.mocked(cloneRepo).mockReset();
+      vi.mocked(cloneRepo).mockImplementation(
+        makeFailingClone('fatal: repository not found')
+      );
+      const malformedLogger = makeCapturingLogger();
+      const malformedResult = await loadUserPrompts(
+        malformedLogger.logger,
+        false,
+        { repoUrl: 'https://invalid.example.test/missing.git' }
+      );
+      expect(malformedResult).toEqual([]);
+      // In-memory cacheState still tracks the env-var repo URL.
+      expect(getUserPromptsCacheState()).toMatchObject({ repoUrl: ENV_REPO });
+
+      // 3. Subsequent no-override call recovers — disk was wiped, so the
+      //    loader re-clones the env-var repo.
+      vi.mocked(cloneRepo).mockReset();
+      vi.mocked(cloneRepo).mockImplementation(makeSuccessfulClone());
+      const restoredLogger = makeCapturingLogger();
+      const restored = await loadUserPrompts(restoredLogger.logger);
+      expect(restored).toEqual(initial);
+      expect(getUserPromptsCacheState()).toMatchObject({ repoUrl: ENV_REPO });
+      expect(vi.mocked(cloneRepo).mock.calls[0][0]).toBe(ENV_REPO);
+    });
+  });
+
+  describe('Credential scrubbing', () => {
+    test('credentials in override repoUrl are scrubbed from log output', async () => {
+      const secret = 'sup3r-secret-token-xyz';
+      const credUrl = `https://user:${secret}@github.com/example-org/private.git`;
+
+      vi.mocked(cloneRepo).mockReset();
+      vi.mocked(cloneRepo).mockImplementation(
+        makeFailingClone(`fatal: could not access ${credUrl}`)
+      );
+
+      const { logger, calls } = makeCapturingLogger();
+      const result = await loadUserPrompts(logger, false, { repoUrl: credUrl });
+
+      expect(result).toEqual([]);
+      const serialized = JSON.stringify(calls);
+      expect(serialized).not.toContain(secret);
+      expect(serialized).toContain('***@github.com/example-org/private.git');
+    });
+
+    test('token-bearing git errors are scrubbed in the outer "Failed to load user prompts" log', async () => {
+      const secret = 'tok_outer_catch_secret_42';
+      const tokenUrl = `https://x-access-token:${secret}@github.com/example-org/private.git`;
+
+      vi.mocked(cloneRepo).mockReset();
+      vi.mocked(cloneRepo).mockImplementation(
+        makeFailingClone(`Cloning into 'foo'... fatal: ${tokenUrl} not found`)
+      );
+
+      const { logger, calls } = makeCapturingLogger();
+      const result = await loadUserPrompts(logger, false, {
+        repoUrl: 'https://github.com/example-org/private.git',
+      });
+
+      expect(result).toEqual([]);
+      const outerErrors = calls.filter(
+        c =>
+          c.level === 'error' &&
+          c.message ===
+            'Failed to load user prompts, falling back to built-in only'
+      );
+      expect(outerErrors.length).toBeGreaterThan(0);
+      expect(JSON.stringify(outerErrors)).not.toContain(secret);
+    });
+  });
+});

--- a/tests/unit/core/user-prompts-source.test.ts
+++ b/tests/unit/core/user-prompts-source.test.ts
@@ -80,10 +80,90 @@ describe('computePromptsSource (PRD #581)', () => {
   });
 
   // Stability: the CLI relies on a stable source value to identify "skills it
-  // wrote". sanitizeUrlForLogging is deterministic, so two identical
+  // wrote". scrubSourceUrl is deterministic, so two identical
   // credential-bearing inputs must produce the same scrubbed output.
   test('source value is stable across calls for the same credential-bearing input', () => {
     const input = { repoUrl: 'https://user:s3cret-tok@github.com/orgA/skills' };
     expect(computePromptsSource(input)).toBe(computePromptsSource(input));
+  });
+
+  // CodeRabbit Major A: query-string secrets must be redacted in `source`,
+  // not just userinfo. The CLI writes this value into on-disk skill frontmatter
+  // verbatim, so an unscrubbed ?access_token=... persists across invocations.
+  describe('query-string credential redaction (CodeRabbit Major A)', () => {
+    test('redacts ?access_token= value', () => {
+      const result = computePromptsSource({
+        repoUrl: 'https://github.com/foo/bar?access_token=ghp_supersecret123',
+      });
+      expect(result).not.toContain('ghp_supersecret123');
+      expect(result).toContain('access_token=***');
+    });
+
+    test('redacts ?token= value and preserves non-credential params', () => {
+      const result = computePromptsSource({
+        repoUrl: 'https://github.com/foo/bar?token=abc&page=2',
+      });
+      expect(result).not.toContain('abc');
+      expect(result).toContain('token=***');
+      expect(result).toContain('page=2');
+    });
+
+    test.each(['Token', 'TOKEN', 'ApiKey', 'API_KEY', 'private_token'])(
+      'is case-insensitive: %s value is redacted',
+      paramName => {
+        const result = computePromptsSource({
+          repoUrl: `https://github.com/foo/bar?${paramName}=raw-secret-xyz`,
+        });
+        expect(result).not.toContain('raw-secret-xyz');
+        expect(result).toContain(`${paramName}=***`);
+      }
+    );
+
+    test.each(['secret', 'password', 'auth', 'credential'])(
+      'redacts ?%s= value',
+      paramName => {
+        const result = computePromptsSource({
+          repoUrl: `https://github.com/foo/bar?${paramName}=raw-value-zzz`,
+        });
+        expect(result).not.toContain('raw-value-zzz');
+        expect(result).toContain(`${paramName}=***`);
+      }
+    );
+
+    test('scrubs BOTH userinfo and query params when present together', () => {
+      const result = computePromptsSource({
+        repoUrl: 'https://user:pwd@host.example.test/repo?secret=x',
+      });
+      // userinfo scrub from sanitizeUrlForLogging.
+      expect(result).not.toContain('pwd');
+      expect(result).toContain('***:***@host.example.test');
+      // query-param scrub from the new helper.
+      expect(result).not.toContain('secret=x');
+      expect(result).toContain('secret=***');
+    });
+
+    test('does not touch non-credential query params', () => {
+      const result = computePromptsSource({
+        repoUrl: 'https://github.com/foo/bar?page=2&sort=asc&ref=v1.0',
+      });
+      expect(result).toContain('page=2');
+      expect(result).toContain('sort=asc');
+      expect(result).toContain('ref=v1.0');
+    });
+
+    test('query-scrub is stable: same input twice → same output', () => {
+      const input = {
+        repoUrl: 'https://github.com/a/b?access_token=tok&page=2',
+      };
+      expect(computePromptsSource(input)).toBe(computePromptsSource(input));
+    });
+
+    test('scrubs query-string credentials in env-var path too', () => {
+      process.env.DOT_AI_USER_PROMPTS_REPO =
+        'https://github.com/org/env-repo.git?api_key=env_secret_42';
+      const result = computePromptsSource(undefined);
+      expect(result).not.toContain('env_secret_42');
+      expect(result).toContain('api_key=***');
+    });
   });
 });

--- a/tests/unit/core/user-prompts-source.test.ts
+++ b/tests/unit/core/user-prompts-source.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit Tests: computePromptsSource (PRD #581)
+ *
+ * The `source` field in /api/v1/prompts responses is the CLI tagging key per
+ * the PRD wire contract. The CLI writes this string verbatim into the
+ * `source:` frontmatter of every skill file it generates, and uses it to wipe
+ * only its own slice on subsequent invocations. The contract must therefore
+ * be:
+ *
+ *   - override supplied              → override.repoUrl
+ *   - no override, env-var configured → DOT_AI_USER_PROMPTS_REPO
+ *   - no override, no env-var         → "built-in"
+ *
+ * These tests cover the pure function so the REST and MCP layers can share
+ * a stable implementation without each duplicating the env-var lookup.
+ */
+
+import { describe, test, expect, beforeEach, afterAll } from 'vitest';
+import { computePromptsSource } from '../../../src/core/user-prompts-loader';
+
+describe('computePromptsSource (PRD #581)', () => {
+  const savedRepo = process.env.DOT_AI_USER_PROMPTS_REPO;
+
+  beforeEach(() => {
+    delete process.env.DOT_AI_USER_PROMPTS_REPO;
+  });
+
+  afterAll(() => {
+    if (savedRepo !== undefined)
+      process.env.DOT_AI_USER_PROMPTS_REPO = savedRepo;
+  });
+
+  test('returns "built-in" when no override and no env-var repo is configured', () => {
+    expect(computePromptsSource(undefined)).toBe('built-in');
+  });
+
+  test('returns env-var URL when no override but DOT_AI_USER_PROMPTS_REPO is set', () => {
+    process.env.DOT_AI_USER_PROMPTS_REPO =
+      'https://github.com/org/env-repo.git';
+    expect(computePromptsSource(undefined)).toBe(
+      'https://github.com/org/env-repo.git'
+    );
+  });
+
+  test('returns override URL verbatim when override is supplied (regardless of env-var)', () => {
+    process.env.DOT_AI_USER_PROMPTS_REPO =
+      'https://github.com/org/env-repo.git';
+    expect(
+      computePromptsSource({
+        repoUrl: 'https://github.com/orgA/skills',
+      })
+    ).toBe('https://github.com/orgA/skills');
+  });
+
+  test('returns override URL even when env-var is unset', () => {
+    expect(
+      computePromptsSource({
+        repoUrl: 'https://github.com/orgB/skills',
+      })
+    ).toBe('https://github.com/orgB/skills');
+  });
+
+  // F1: source must NOT echo credentials embedded in the URL. The CLI writes
+  // this value into skill frontmatter on disk; an unscrubbed value would
+  // persist a token there.
+  test('scrubs credentials from override URL before returning', () => {
+    const result = computePromptsSource({
+      repoUrl: 'https://user:s3cret-tok@github.com/orgA/skills',
+    });
+    expect(result).not.toContain('s3cret-tok');
+    expect(result).toMatch(/^https:\/\/\*{3}:\*{3}@github\.com\/orgA\/skills/);
+  });
+
+  test('scrubs credentials from env-var URL before returning', () => {
+    process.env.DOT_AI_USER_PROMPTS_REPO =
+      'https://x-access-token:env-tok@github.com/org/env-repo.git';
+    const result = computePromptsSource(undefined);
+    expect(result).not.toContain('env-tok');
+    expect(result).toContain('***@github.com/org/env-repo.git');
+  });
+
+  // Stability: the CLI relies on a stable source value to identify "skills it
+  // wrote". sanitizeUrlForLogging is deterministic, so two identical
+  // credential-bearing inputs must produce the same scrubbed output.
+  test('source value is stable across calls for the same credential-bearing input', () => {
+    const input = { repoUrl: 'https://user:s3cret-tok@github.com/orgA/skills' };
+    expect(computePromptsSource(input)).toBe(computePromptsSource(input));
+  });
+});

--- a/tests/unit/interfaces/rest-api-url-scrubbing.test.ts
+++ b/tests/unit/interfaces/rest-api-url-scrubbing.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit Tests: sanitizeRequestUrlForLogging (PRD #581 F3)
+ *
+ * REST API request logging echoes req.url. With PRD #581 the query string
+ * may carry `?repo=<user-supplied-url>` whose value can include credentials.
+ * The helper must rewrite the `repo` value to its scrubbed form so the raw
+ * token never reaches the log.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { sanitizeRequestUrlForLogging } from '../../../src/interfaces/rest-api';
+
+describe('sanitizeRequestUrlForLogging (PRD #581 F3)', () => {
+  test('returns undefined as-is', () => {
+    expect(sanitizeRequestUrlForLogging(undefined)).toBe(undefined);
+  });
+
+  test('returns empty string as-is', () => {
+    expect(sanitizeRequestUrlForLogging('')).toBe('');
+  });
+
+  test('passes through URLs without a query string', () => {
+    expect(sanitizeRequestUrlForLogging('/api/v1/prompts')).toBe(
+      '/api/v1/prompts'
+    );
+  });
+
+  test('passes through URLs without a `repo` query param', () => {
+    expect(sanitizeRequestUrlForLogging('/api/v1/prompts?foo=bar')).toBe(
+      '/api/v1/prompts?foo=bar'
+    );
+  });
+
+  test('passes through credential-free `repo` values unchanged', () => {
+    const url = '/api/v1/prompts?repo=https%3A%2F%2Fgithub.com%2Forg%2Frepo';
+    const result = sanitizeRequestUrlForLogging(url);
+    // The URL is reconstructed but the substantive content is preserved.
+    expect(result).toContain('repo=');
+    expect(result).toContain('github.com');
+    expect(result).toContain('org');
+    expect(result).toContain('repo');
+  });
+
+  test('scrubs credentials embedded in the `repo` value', () => {
+    const url =
+      '/api/v1/prompts?repo=https%3A%2F%2Fuser%3As3cret-tok%40github.com%2Forg%2Frepo';
+    const result = sanitizeRequestUrlForLogging(url);
+    expect(result).toBeDefined();
+    expect(result).not.toContain('s3cret-tok');
+    // Scrubbed form should include the masked credentials marker.
+    expect(decodeURIComponent(result as string)).toContain(
+      '***@github.com/org/repo'
+    );
+  });
+
+  test('preserves other query params alongside the `repo` rewrite', () => {
+    const url =
+      '/api/v1/prompts?other=v1&repo=https%3A%2F%2Fu%3At%40h%2Fr&another=v2';
+    const result = sanitizeRequestUrlForLogging(url);
+    expect(result).toBeDefined();
+    expect(result).toContain('other=v1');
+    expect(result).toContain('another=v2');
+    expect(result).not.toContain('u:t@');
+  });
+});

--- a/tests/unit/interfaces/rest-api-url-scrubbing.test.ts
+++ b/tests/unit/interfaces/rest-api-url-scrubbing.test.ts
@@ -1,14 +1,47 @@
 /**
- * Unit Tests: sanitizeRequestUrlForLogging (PRD #581 F3)
+ * Unit Tests: sanitizeRequestUrlForLogging (PRD #581 F3 + CodeRabbit Major B)
  *
  * REST API request logging echoes req.url. With PRD #581 the query string
  * may carry `?repo=<user-supplied-url>` whose value can include credentials.
  * The helper must rewrite the `repo` value to its scrubbed form so the raw
  * token never reaches the log.
+ *
+ * CodeRabbit Major B added a stricter guard for the catch path: on URL parse
+ * failure, the helper redacts the entire query string (keeping just the
+ * pathname plus a constant placeholder), rather than echoing the input
+ * verbatim. An unparseable URL is more likely than a parseable one to hide
+ * a credential, so the catch path must NOT echo the raw query.
  */
 
-import { describe, test, expect } from 'vitest';
-import { sanitizeRequestUrlForLogging } from '../../../src/interfaces/rest-api';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  sanitizeRequestUrlForLogging,
+  UNPARSEABLE_QUERY_PLACEHOLDER,
+} from '../../../src/interfaces/rest-api';
+
+// Module-scope mock used by the "unparseable input" describe block below.
+// `URL` in rest-api.ts is imported from 'node:url', so vi.stubGlobal does NOT
+// reach it — we mock 'node:url' for this test file instead. The replacement
+// constructor throws ONLY when (process as any).__forceUrlThrow === true and
+// the second argument is the exact base the helper uses
+// ('http://internal.invalid'). Anywhere else (success-path tests, library
+// internals) it falls through to the real URL constructor.
+vi.mock('node:url', async () => {
+  const actual = await vi.importActual<typeof import('node:url')>('node:url');
+  class ConditionallyThrowingURL extends actual.URL {
+    constructor(input: string, base?: string | URL) {
+      if (
+        base === 'http://internal.invalid' &&
+        (process as unknown as { __forceUrlThrow?: boolean })
+          .__forceUrlThrow === true
+      ) {
+        throw new Error('mocked URL parser failure');
+      }
+      super(input, base);
+    }
+  }
+  return { ...actual, URL: ConditionallyThrowingURL };
+});
 
 describe('sanitizeRequestUrlForLogging (PRD #581 F3)', () => {
   test('returns undefined as-is', () => {
@@ -34,7 +67,6 @@ describe('sanitizeRequestUrlForLogging (PRD #581 F3)', () => {
   test('passes through credential-free `repo` values unchanged', () => {
     const url = '/api/v1/prompts?repo=https%3A%2F%2Fgithub.com%2Forg%2Frepo';
     const result = sanitizeRequestUrlForLogging(url);
-    // The URL is reconstructed but the substantive content is preserved.
     expect(result).toContain('repo=');
     expect(result).toContain('github.com');
     expect(result).toContain('org');
@@ -47,7 +79,6 @@ describe('sanitizeRequestUrlForLogging (PRD #581 F3)', () => {
     const result = sanitizeRequestUrlForLogging(url);
     expect(result).toBeDefined();
     expect(result).not.toContain('s3cret-tok');
-    // Scrubbed form should include the masked credentials marker.
     expect(decodeURIComponent(result as string)).toContain(
       '***@github.com/org/repo'
     );
@@ -61,5 +92,51 @@ describe('sanitizeRequestUrlForLogging (PRD #581 F3)', () => {
     expect(result).toContain('other=v1');
     expect(result).toContain('another=v2');
     expect(result).not.toContain('u:t@');
+  });
+
+  // CodeRabbit Major B: on parse failure, do not echo the raw query string.
+  // The WHATWG URL parser in Node is extremely lenient and canonicalizes
+  // most malformed inputs rather than throwing, so we mock the URL
+  // constructor to throw and pin the catch behavior directly. The behavior
+  // we want to guarantee is: "if URL ever throws on us in production, the
+  // log line does NOT echo a credential-bearing query string verbatim."
+  describe('unparseable input (CodeRabbit Major B)', () => {
+    const _proc = process as unknown as { __forceUrlThrow?: boolean };
+
+    beforeEach(() => {
+      _proc.__forceUrlThrow = true;
+    });
+
+    afterEach(() => {
+      delete _proc.__forceUrlThrow;
+    });
+
+    test('does not throw on unparseable input', () => {
+      expect(() =>
+        sanitizeRequestUrlForLogging('/api/v1/prompts?repo=anything')
+      ).not.toThrow();
+    });
+
+    test('redacts the entire query string when URL fails to parse', () => {
+      const result = sanitizeRequestUrlForLogging(
+        '/api/v1/prompts?repo=https://x:tok-leaked-xyz@host/r'
+      );
+      expect(result).toBeDefined();
+      // No part of the raw query — including the embedded credential —
+      // leaks into the returned log string.
+      expect(result).not.toContain('repo=');
+      expect(result).not.toContain('tok-leaked-xyz');
+      expect(result).not.toContain('x:tok');
+      // The pathname is preserved so the log is still useful for triage.
+      expect(result).toContain('/api/v1/prompts');
+      // The placeholder is a fixed constant for log-grepping.
+      expect(result?.endsWith(UNPARSEABLE_QUERY_PLACEHOLDER)).toBe(true);
+    });
+
+    test('unparseable URL without a query string is returned unchanged', () => {
+      // No `?` short-circuits before we ever enter the parse branch.
+      const malformed = '/api/v1/prompts';
+      expect(sanitizeRequestUrlForLogging(malformed)).toBe(malformed);
+    });
   });
 });

--- a/tests/unit/mock-server/fixtures.test.ts
+++ b/tests/unit/mock-server/fixtures.test.ts
@@ -9,6 +9,10 @@ import { describe, test, expect } from 'vitest';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { matchRoute } from '../../../mock-server/routes';
+import {
+  applyPromptsRepoOverride,
+  isPromptsRoutePath,
+} from '../../../mock-server/prompts-override';
 
 const MOCK_SERVER_DIR = join(
   import.meta.dirname,
@@ -91,6 +95,8 @@ describe('Mock Server Fixtures', () => {
               arguments: expect.any(Array),
             }),
           ]),
+          // PRD #581: source field present on the no-override fixture.
+          source: 'built-in',
         },
         meta: {
           timestamp: expect.any(String),
@@ -231,6 +237,8 @@ describe('Mock Server Fixtures', () => {
               }),
             }),
           ]),
+          // PRD #581: source field present on the no-override fixture.
+          source: 'built-in',
         },
         meta: {
           timestamp: expect.any(String),
@@ -315,6 +323,74 @@ describe('Mock Server Fixtures', () => {
         token_type: 'bearer',
         expires_in: expect.any(Number),
       });
+    });
+  });
+
+  // PRD #581 M2b: mock-server parity for the per-request `repo` override.
+  describe('Per-request override helpers (PRD #581)', () => {
+    test('isPromptsRoutePath matches list, refresh, and get-by-name paths', () => {
+      expect(isPromptsRoutePath('/api/v1/prompts')).toBe(true);
+      expect(isPromptsRoutePath('/api/v1/prompts/refresh')).toBe(true);
+      expect(isPromptsRoutePath('/api/v1/prompts/troubleshoot-pod')).toBe(true);
+      expect(isPromptsRoutePath('/api/v1/prompts/prd-create')).toBe(true);
+    });
+
+    test('isPromptsRoutePath does not match unrelated paths', () => {
+      expect(isPromptsRoutePath('/api/v1/promptsX')).toBe(false);
+      expect(isPromptsRoutePath('/api/v1/tools')).toBe(false);
+      expect(isPromptsRoutePath('/api/v1/prompts/refresh/extra')).toBe(false);
+      expect(isPromptsRoutePath('/')).toBe(false);
+    });
+
+    test('applyPromptsRepoOverride leaves fixture untouched when repo is undefined', () => {
+      const fixture = { success: true, data: { source: 'built-in', x: 1 } };
+      expect(applyPromptsRepoOverride(fixture, undefined)).toEqual(fixture);
+      expect(applyPromptsRepoOverride(fixture, '')).toEqual(fixture);
+    });
+
+    test('applyPromptsRepoOverride echoes repo into data.source', () => {
+      const fixture = {
+        success: true,
+        data: {
+          prompts: [{ name: 'foo', description: 'bar', arguments: [] }],
+          source: 'built-in',
+        },
+        meta: { timestamp: 't', version: '1.0.0' },
+      };
+      const repo = 'https://github.com/example-org/skills';
+      const result = applyPromptsRepoOverride(fixture, repo) as typeof fixture;
+
+      expect(result).toMatchObject({
+        success: true,
+        data: {
+          source: repo,
+          prompts: fixture.data.prompts,
+        },
+        meta: fixture.meta,
+      });
+      // Original fixture must not be mutated.
+      expect(fixture.data.source).toBe('built-in');
+    });
+
+    test('applyPromptsRepoOverride passes through fixtures without a data object', () => {
+      expect(applyPromptsRepoOverride(null, 'https://x.test')).toBe(null);
+      expect(applyPromptsRepoOverride('plain-string', 'https://x.test')).toBe(
+        'plain-string'
+      );
+      expect(
+        applyPromptsRepoOverride({ success: true }, 'https://x.test')
+      ).toEqual({
+        success: true,
+      });
+    });
+
+    test('refresh fixture has the no-override source value', async () => {
+      const fixture = (await loadFixture(
+        'prompts/refresh-success.json'
+      )) as any;
+      // Was 'built-in+repository' pre-M2; PRD #581 wire contract now requires
+      // the env-var URL (or 'built-in' when none is configured).
+      expect(fixture.data.source).toBe('built-in');
     });
   });
 });

--- a/tests/unit/mock-server/read-json-body.test.ts
+++ b/tests/unit/mock-server/read-json-body.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit Tests: mock-server readJsonBody body-size cap (PRD #581 F4)
+ *
+ * The mock-server's JSON body reader accepts arbitrary-size payloads by
+ * default; uncapped buffering trivially DOSes the process. F4 added a 1 MB
+ * cap enforced two ways:
+ *   - upfront via Content-Length header
+ *   - defense-in-depth via accumulated chunk size during read
+ *
+ * Both paths must throw BodyTooLargeError so the HTTP handler can return 413
+ * instead of crashing to 500.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { Readable } from 'node:stream';
+import type { IncomingMessage } from 'node:http';
+import {
+  MAX_BODY_BYTES,
+  BodyTooLargeError,
+  readJsonBody,
+} from '../../../mock-server/read-json-body';
+
+// readJsonBody only touches req.headers and the data/end/error events that
+// Readable streams already implement. Tag the stream as IncomingMessage for
+// the type cast — we're not exercising any HTTP-specific behavior.
+function makeRequest(
+  body: Buffer,
+  headers: Record<string, string> = {}
+): IncomingMessage {
+  const stream = Readable.from([body]) as unknown as IncomingMessage & {
+    headers: Record<string, string>;
+    destroy: () => void;
+  };
+  stream.headers = headers;
+  stream.destroy = () => {
+    /* noop for test */
+  };
+  return stream;
+}
+
+describe('readJsonBody body-size cap (PRD #581 F4)', () => {
+  test('parses a small JSON body', async () => {
+    const body = Buffer.from(JSON.stringify({ repo: 'https://x.test' }));
+    const req = makeRequest(body, { 'content-length': String(body.length) });
+    await expect(readJsonBody(req)).resolves.toEqual({
+      repo: 'https://x.test',
+    });
+  });
+
+  test('returns undefined for empty body', async () => {
+    const req = makeRequest(Buffer.from(''), { 'content-length': '0' });
+    await expect(readJsonBody(req)).resolves.toBe(undefined);
+  });
+
+  test('returns undefined for malformed JSON', async () => {
+    const body = Buffer.from('not-json{');
+    const req = makeRequest(body, { 'content-length': String(body.length) });
+    await expect(readJsonBody(req)).resolves.toBe(undefined);
+  });
+
+  test('rejects upfront via Content-Length when declared length exceeds the cap', async () => {
+    // Body is empty, but the declared header lies about size.
+    const req = makeRequest(Buffer.from(''), {
+      'content-length': String(MAX_BODY_BYTES + 1),
+    });
+    await expect(readJsonBody(req)).rejects.toBeInstanceOf(BodyTooLargeError);
+  });
+
+  test('rejects during read when accumulated bytes exceed the cap (Content-Length absent)', async () => {
+    // No Content-Length header, but the stream emits more than the cap.
+    // Use a single chunk slightly over MAX_BODY_BYTES.
+    const oversize = Buffer.alloc(MAX_BODY_BYTES + 16, 'a');
+    const req = makeRequest(oversize, {}); // no content-length header
+    await expect(readJsonBody(req)).rejects.toBeInstanceOf(BodyTooLargeError);
+  });
+
+  test('BodyTooLargeError carries the configured limit', async () => {
+    const req = makeRequest(Buffer.from(''), {
+      'content-length': String(MAX_BODY_BYTES + 1),
+    });
+    try {
+      await readJsonBody(req);
+      throw new Error('expected to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BodyTooLargeError);
+      expect((err as BodyTooLargeError).limit).toBe(MAX_BODY_BYTES);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #581.

Adds an optional `repo` parameter to the prompts REST endpoints that overrides `DOT_AI_USER_PROMPTS_REPO` for a single request, enabling CLI consumers to compose skills from multiple repositories. Fully additive — requests without `repo` behave byte-identically to today.

- `POST /api/v1/prompts/refresh` accepts `{ "repo": "<url>" }` in the body
- `GET /api/v1/prompts` and `POST /api/v1/prompts/:name` accept `?repo=<url>`
- Response `source` field echoes the override URL (or env-var repo, or `"built-in"`), credentials scrubbed via `sanitizeUrlForLogging`
- Validation: `http`/`https` schemes only; subPath traversal blocked; branch validated via `isValidGitBranch`; non-string `body.repo` returns 400
- Mock-server mirrors the contract; 1 MB body-size cap added
- ~50 new tests across loader / source / REST / mock-server / log-scrubbing / body-cap layers

## ⚠️ Security trade-off — please review before merging

The auditor flagged a CRITICAL finding that is explicitly the PRD's MVP trade-off, NOT a regression:

**`DOT_AI_GIT_TOKEN` is sent to whatever host the caller supplies in `repo=`.** There is no host allowlist, no scheme allowlist beyond http/https, and no per-repo token. A caller who submits `https://attacker.example.com/repo` will cause the server to send `DOT_AI_GIT_TOKEN` to `attacker.example.com`.

This matches the PRD's explicit "Out of scope" decisions:
- Per-repo tokens deferred
- URL allowlist / SSRF prevention deferred — "The server is not the security boundary for skill content"
- Deployment model assumes the REST endpoint caller is trusted (self-hosted single-user setups)

If your deployment exposes this endpoint to untrusted callers, **do not merge** without first adding a host gate. For trusted-caller deployments (the PRD's target scenario), the trade-off is acceptable.

## Companion consumer — dot-ai-cli

A pre-release mock-server image is published for the CLI companion team to test against before merge:

- Image: `ghcr.io/vfarcic/dot-ai-mock-server:feat-prd-581`
- Digest: `sha256:78b70815a3b39d8f95be6d246b2fa60ee2ad17d228dd76aae237ec95bc508afa`
- Multi-arch: linux/amd64 + linux/arm64
- `:latest` was NOT overwritten (digest unchanged at `sha256:79c18bb19a939c5c26ba64d9d1e21e841a3097cdc6978d3c11c6d92200f67abb`)

CLI verification checklist is in `prds/581-per-request-user-prompts-repo.md` under "Instructions for the dot-ai-cli companion team". After this PR merges, the canonical `:latest` should be republished via the normal release flow.

## Open follow-ups (not in scope, intentionally deferred)

- Per-repo token mapping (`DOT_AI_GIT_TOKEN_<host>` or similar) — closes the CRITICAL above
- Per-repo cache map (`Map<repoUrl, CacheState>`) — fixes the cache-thrashing wart and unblocks happy-path REST integration tests (today's single-slot cache races across vitest fork-pool files)
- Per-request `branch` and `path` exposed via REST (interface already accepts them)
- CLI companion PRD merge in `vfarcic/dot-ai-cli`
- Audit MEDIUMs deferred this round: MCP-side request-log scrubbing, real-server `parseRequestBody` size cap, `scrubCredentials` query-string/path-component coverage

## Test plan

- [ ] CI: `npm run test:unit` (target: 438/438 pass)
- [ ] CI: `npm run test:integration` (existing 34 Qdrant/embedding infra failures are pre-existing — must not increase)
- [ ] CI: `cd mock-server && npm run build`
- [ ] CI: tsc + eslint clean
- [ ] Manual: hit each new endpoint with and without `repo` against a real server; confirm `source` value matches contract
- [ ] Manual: confirm credentials in `repo` URL do not appear in server logs or response body
- [ ] Manual: dot-ai-cli team runs end-to-end test against `ghcr.io/vfarcic/dot-ai-mock-server:feat-prd-581`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompts REST endpoints accept an optional per-request `repo` override; responses include a deterministic, credential-scrubbed `source` tag.

* **Documentation**
  * Added Prompts Endpoints and CLI guidance with examples, validation rules, and caveats for per-request repo overrides.

* **Bug Fixes**
  * Request body size capped (413 on oversized payloads); repository credentials are scrubbed from logs and responses.

* **Tests**
  * Expanded integration and unit tests covering per-request overrides, scrubbing, validation, and body-size behavior.

* **Chores**
  * Release version bumped to 1.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->