### PR TITLE
fix: Update the deployment.yaml manifest to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The current image tag 'nginx:v999-nonexistent' does not exist and cannot be pulled. Changing to 'nginx:latest' uses an official, available image. Argo CD will automatically detect the change and sync the deployment to the cluster due to the automated sync policy enabled on the Application.

**Risk Level:** low