### PR TITLE
fix: Fix container image tag from invalid 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image to 'nginx:latest' resolves the ImagePullBackOff error. This is a valid, publicly available image that will pull successfully. Argo CD has automated sync enabled and will automatically deploy the corrected manifest.

**Risk Level:** low