### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the non-existent image tag to a valid one (nginx:latest) will allow the kubelet to successfully pull the image and start the pod. Argo CD's automated sync will detect and apply this change.

**Risk Level:** low