### PR TITLE
fix: Update deployment.yaml to use valid nginx:latest image tag instead of nginx:v999-nonexistent

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to nginx:latest provides a valid, publicly available image that kubelet can pull successfully. Argo CD will automatically resync and redeploy the pod with the correct image, resolving the ImagePullBackOff error.

**Risk Level:** low