### PR TITLE
fix: Update deployment manifest to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' provides a valid, publicly available image. Argo CD will automatically sync this change and the deployment will pull the correct image, resolving the ImagePullBackOff errors.

**Risk Level:** low