### PR TITLE
fix: Update the container image tag in the deployment manifest from invalid 'nginx:v999-nonexistent' to valid 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Using a valid, stable image tag allows the container to be successfully pulled and the pod to transition from ImagePullBackOff to Running status. The latest tag is widely available and commonly used for nginx containers.

**Risk Level:** low