### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag (nginx:latest)

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from 'nginx:v999-nonexistent' to 'nginx:latest' resolves the ImagePullBackOff error. This is a valid, publicly available image that kubelet can successfully pull. Argo CD will automatically sync this change due to the configured auto-sync policy, and pods will be recreated with the working image.

**Risk Level:** low