### PR TITLE
fix: Fix invalid image tag in deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The current image tag references a non-existent image. Changing to 'nginx:latest' provides a valid, publicly available image that will pull successfully. Argo CD's automatic sync policy will detect the updated manifest and redeploy with the corrected image, allowing the pod to start successfully.

**Risk Level:** low