### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from non-existent 'v999-nonexistent' to 'latest' resolves the ImagePullBackOff. 'latest' is a valid, publicly available nginx image tag in Docker registry. Argo CD with auto-sync enabled will automatically reconcile and deploy the corrected image.

**Risk Level:** low