### PR TITLE
fix: Update deployment manifest with valid nginx image tag in source Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag to 'nginx:latest' provides a valid, publicly available image. Since ArgoCD has automated sync enabled, it will automatically detect the change and reconcile the cluster state. The pod will then successfully pull the image and transition to Running state.

**Risk Level:** low