### PR TITLE
fix: Update deployment image tag to valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to a valid, existing image (nginx:latest) allows the kubelet to successfully pull the image and start the pod. The change will be automatically synced by Argo CD due to automated sync policy.

**Risk Level:** low