### PR TITLE
fix(deps): bump @grpc/grpc-js to 1.14.4 (GHSA-5375-pq7m-f5r2, GHSA-99f4-grh7-6pcq)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/openai-compatible": "^2.0.35",
         "@ai-sdk/xai": "^3.0.67",
-        "@grpc/grpc-js": "^1.14.3",
+        "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.0",
         "@kubernetes/client-node": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -932,10 +932,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
-      "license": "Apache-2.0",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/openai-compatible": "^2.0.35",
     "@ai-sdk/xai": "^3.0.67",
-    "@grpc/grpc-js": "^1.14.3",
+    "@grpc/grpc-js": "^1.14.4",
     "@grpc/proto-loader": "^0.8.0",
     "@kubernetes/client-node": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
## Summary

Bumps `@grpc/grpc-js` `1.14.3 → 1.14.4` to resolve two **high-severity** advisories that the `Security Analysis` (`better-npm-audit`) CI step now flags:

- GHSA-5375-pq7m-f5r2 (npm advisory 1120582)
- GHSA-99f4-grh7-6pcq (npm advisory 1120588)

These advisories were published after `main` last ran CI, so the audit fails on **every** PR (e.g. #628) regardless of its contents — this is a repo-wide blocker. `@grpc/grpc-js` is a direct dependency (also pulled by the OpenTelemetry exporters).

## Validation (local)

- `npx --no-install better-npm-audit audit --level moderate` → **"All good!"** (both advisories cleared)
- `npm run build` → pass
- `npm run test:unit` → 481 passed

Full integration suite runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal gRPC dependency to the latest patch version for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->