### PR TITLE
fix: Fix the invalid nginx image tag in deployment.yaml

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' resolves the ImagePullBackOff by using a valid, existing image. Argo CD will automatically detect the change and sync it to the cluster, causing pods to be recreated with the correct image.

**Risk Level:** low