### PR TITLE
fix: Fix container image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' (a valid, existing image) allows the kubelet to successfully pull the image and start the container. Argo CD's sync policy is set to auto-sync with self-heal enabled, so it will automatically apply this change when it's detected in the repository.

**Risk Level:** low