### PR TITLE
fix: Update deployment.yaml to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image from 'nginx:v999-nonexistent' to 'nginx:latest' (or any valid tag) allows Kubernetes to successfully pull the image and start the pod. ArgoCD will automatically detect and apply this change.

**Risk Level:** low