### PR TITLE
fix: Fix the invalid image tag in the deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Using 'nginx:latest' is a valid, publicly available image that will allow the container to be pulled and the pod to start successfully. Argo CD's automated sync (enabled in the Application spec) will automatically detect the change in Git and redeploy the application.

**Risk Level:** low