### PR TITLE
fix: Fix invalid nginx image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'v999-nonexistent' is invalid and doesn't exist in any Docker registry. Changing to 'nginx:latest' uses a valid, publicly available image. Argo CD with automated sync enabled will immediately detect and apply this change.

**Risk Level:** low