### PR TITLE
fix: Update image tag to valid nginx image in source deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from non-existent 'v999-nonexistent' to 'latest' (a valid, stable tag) resolves the ImagePullBackOff error. Argo CD will automatically sync the change to the cluster.

**Risk Level:** low