### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag (nginx:latest)

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag 'nginx:v999-nonexistent' is the root cause. Changing to 'nginx:latest' provides a valid, stable image. Since the resource is GitOps-managed, updating the source repository ensures Argo CD will sync the change and recreate pods with the corrected image.

**Risk Level:** low