### PR TITLE
fix: Fix the invalid image tag in the deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Replacing the non-existent image tag with a valid stable nginx image resolves the ImagePullBackOff error. Argo CD will automatically sync this change due to the enabled auto-sync policy.

**Risk Level:** low