### PR TITLE
fix: Fix the invalid nginx image tag in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image from non-existent tag 'v999-nonexistent' to valid 'latest' tag allows the kubelet to successfully pull the image. Argo CD's automated sync policy will detect the Git repository change and automatically deploy the corrected version.

**Risk Level:** low