### PR TITLE
fix: Update deployment.yaml with valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'nginx:v999-nonexistent' does not exist in the Docker registry. Changing to 'nginx:latest' provides a valid, stable nginx image that will allow the container to be pulled and the pod to start successfully. Argo CD will automatically detect and apply this change.

**Risk Level:** low