### PR TITLE
fix: Fix the invalid image tag in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from 'nginx:v999-nonexistent' to 'nginx:latest' (or another valid tag) allows kubelet to successfully pull the image from the registry. Argo CD will automatically detect the change via its sync mechanism and update the deployment, causing new pods to be created with the valid image.

**Risk Level:** low