### PR TITLE
fix: Update the deployment image tag in the source Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image to a valid tag (nginx:latest) that exists in the Docker registry will allow the pod to successfully pull the image and start. Argo CD's automated sync with self-heal enabled will automatically apply this change to the cluster.

**Risk Level:** low