### PR TITLE
fix: Fix the invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing from a non-existent image tag to a valid, commonly-used nginx:latest tag resolves the ImagePullBackOff. Argo CD's automated sync will immediately reconcile the deployment and restart pods with the valid image.

**Risk Level:** low