### PR TITLE
fix: Fix the invalid image tag in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' provides a valid, publicly available image that can be successfully pulled. Argo CD's automated sync policy will detect the change and apply it to the cluster, allowing pods to start successfully.

**Risk Level:** low