### PR TITLE
fix: Fix the nginx image tag in the deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The deployment manifest references a non-existent image tag. Updating to a valid image tag (nginx:latest) allows the image to be pulled from the registry and pods to start successfully. ArgoCD will automatically sync this change due to its automated sync policy.

**Risk Level:** low