### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from a non-existent tag to a valid 'nginx:latest' tag will allow the image pull to succeed. Argo CD's automated sync with selfHeal enabled will automatically reconcile the change once pushed to Git.

**Risk Level:** low