### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag to a valid, publicly available version allows the kubelet to successfully pull the image. Argo CD's automated sync will apply this change and restart the pod.

**Risk Level:** low