### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image 'nginx:v999-nonexistent' does not exist. Changing to 'nginx:latest' uses a valid, stable image that exists in the official Docker registry. Argo CD will automatically sync this change due to its auto-heal and auto-prune policies.

**Risk Level:** low