### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from the non-existent 'v999-nonexistent' to 'latest' resolves the ImagePullBackOff error. This is a valid, publicly available image tag. Argo CD will automatically detect and sync this change due to its configured automated sync policy.

**Risk Level:** low