### PR TITLE
fix: Update the deployment manifest in Git to use valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to a valid, existing image tag allows the kubelet to successfully pull the image and start the pod. Using 'nginx:latest' ensures a stable, widely available image. Argo CD will automatically sync this change due to configured automated sync policy.

**Risk Level:** low