### PR TITLE
fix: Update image tag to valid nginx version in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image from the non-existent 'nginx:v999-nonexistent' to 'nginx:latest' provides a valid, publicly available image that can be pulled successfully. Argo CD will automatically detect this change and sync it to the cluster within its reconciliation interval, causing the deployment to pull the correct image and pods to start.

**Risk Level:** low