### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'v999-nonexistent' is invalid and cannot be pulled. Changing to 'nginx:latest' provides a valid, available image. Argo CD will automatically sync this change due to its configured auto-sync policy (Automated: Prune=true, SelfHeal=true).

**Risk Level:** low