### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' provides a valid, existing image that can be successfully pulled. Argo CD will detect the change and automatically sync the corrected deployment, causing pods to be recreated with the working image.

**Risk Level:** low