### PR TITLE
Fix/375 unified knowledge base

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "mermaid": "^11.15.0",
         "posthog-node": "^5.23.0",
         "simple-git": "^3.32.3",
+        "uuid": "^14.0.0",
         "yaml": "^2.8.0"
       },
       "bin": {
@@ -59,7 +60,6 @@
         "ts-node": "^10.9.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.54.0",
-        "uuid": "^14.0.0",
         "vitest": "^4.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "ts-node": "^10.9.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.54.0",
-    "uuid": "^14.0.0",
     "vitest": "^4.0.0"
   },
   "dependencies": {
@@ -133,6 +132,7 @@
     "mermaid": "^11.15.0",
     "posthog-node": "^5.23.0",
     "simple-git": "^3.32.3",
+    "uuid": "^14.0.0",
     "yaml": "^2.8.0"
   },
   "overrides": {

--- a/packages/agentic-tools/src/tools/knowledge.ts
+++ b/packages/agentic-tools/src/tools/knowledge.ts
@@ -32,9 +32,9 @@ export interface KnowledgeTool {
 
 /**
  * UUID v5 namespace for knowledge chunk IDs
- * Using the URL namespace as base for URI-based IDs
+ * Uses the RFC 4122 DNS namespace as base for URI-based IDs
  */
-const KNOWLEDGE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const KNOWLEDGE_NAMESPACE = uuidv5.DNS;
 
 /**
  * Chunk result returned by the chunking tool

--- a/src/core/knowledge-migration.ts
+++ b/src/core/knowledge-migration.ts
@@ -30,7 +30,7 @@ const LEGACY_COLLECTIONS: Array<{ name: string; tags: string[] }> = [
 /** Target unified collection */
 const KNOWLEDGE_COLLECTION = 'knowledge-base';
 
-export const KNOWLEDGE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+export const KNOWLEDGE_NAMESPACE = uuidv5.DNS;
 
 /**
  * Maximum number of points fetched from a legacy collection in a single

--- a/src/core/knowledge-migration.ts
+++ b/src/core/knowledge-migration.ts
@@ -16,6 +16,7 @@
 import { Logger } from './error-handling';
 import { invokePluginTool, isPluginInitialized } from './plugin-registry';
 import { createHash } from 'crypto';
+import { v5 as uuidv5 } from 'uuid';
 
 const PLUGIN_NAME = 'agentic-tools';
 
@@ -27,6 +28,8 @@ const LEGACY_COLLECTIONS: Array<{ name: string; tags: string[] }> = [
 
 /** Target unified collection */
 const KNOWLEDGE_COLLECTION = 'knowledge-base';
+
+export const KNOWLEDGE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 
 /**
  * Maximum number of points fetched from a legacy collection in a single
@@ -264,7 +267,7 @@ async function migrateLegacyCollection(
 
       await pluginCall('vector_store', {
         collection: KNOWLEDGE_COLLECTION,
-        id: doc.id,
+        id: uuidv5(`legacy://${legacyName}/${doc.id}#0`, KNOWLEDGE_NAMESPACE),
         embedding: doc.vector,
         payload: mergedPayload,
       });

--- a/src/core/knowledge-migration.ts
+++ b/src/core/knowledge-migration.ts
@@ -8,8 +8,9 @@
  * Design decisions:
  * - Idempotent: safe to run multiple times (skips if legacy collections absent)
  * - Non-fatal: migration failures are logged but do not crash the server
- * - Verify-before-delete: legacy collection is only removed after verifying
- *   migrated point count matches the source
+ * - Delete-after-success: the legacy collection is only removed when every point
+ *   stored successfully (failCount === 0); deterministic UUIDv5 IDs prevent
+ *   collisions/overwrites, making store-success gating safe
  * - Tags assigned by collection origin: patterns → ["pattern"], policies → ["policy"]
  */
 

--- a/src/core/knowledge-migration.ts
+++ b/src/core/knowledge-migration.ts
@@ -295,6 +295,8 @@ async function migrateLegacyCollection(
   logger.info(`[migration] Deleted legacy collection '${legacyName}'`);
 }
 
+let migrationInProgress = false;
+
 /**
  * Run the auto-migration check at server startup.
  *
@@ -307,6 +309,12 @@ export async function runKnowledgeMigration(logger: Logger): Promise<void> {
     logger.info('[migration] Plugin not initialised — skipping legacy knowledge migration');
     return;
   }
+
+  if (migrationInProgress) {
+    logger.info('[migration] Migration already in progress — skipping concurrent run');
+    return;
+  }
+  migrationInProgress = true;
 
   try {
     for (const { name, tags } of LEGACY_COLLECTIONS) {
@@ -323,5 +331,7 @@ export async function runKnowledgeMigration(logger: Logger): Promise<void> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error(`[migration] Migration failed — server continues normally: ${msg}`);
+  } finally {
+    migrationInProgress = false;
   }
 }

--- a/src/core/knowledge-service.ts
+++ b/src/core/knowledge-service.ts
@@ -84,7 +84,17 @@ export async function searchKnowledgeBase(params: {
   }
 
   // Generate embedding for the search query
-  const queryEmbedding = await embeddingService.generateEmbedding(query);
+  let queryEmbedding: number[];
+  try {
+    queryEmbedding = await embeddingService.generateEmbedding(query);
+  } catch (err) {
+    return {
+      success: false,
+      chunks: [],
+      totalMatches: 0,
+      error: `Failed to generate query embedding: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 
   // Build filter if uriFilter is provided
   let filter: Record<string, unknown> | undefined;

--- a/src/core/knowledge-service.ts
+++ b/src/core/knowledge-service.ts
@@ -29,6 +29,14 @@ const KNOWLEDGE_COLLECTION = 'knowledge-base';
  */
 const DEFAULT_SEARCH_LIMIT = 20;
 
+let embeddingServiceInstance: EmbeddingService | null = null;
+function getEmbeddingService(): EmbeddingService {
+  if (!embeddingServiceInstance) {
+    embeddingServiceInstance = new EmbeddingService();
+  }
+  return embeddingServiceInstance;
+}
+
 /**
  * Result type for the reusable search function
  */
@@ -64,7 +72,7 @@ export async function searchKnowledgeBase(params: {
   }
 
   // Check embedding service availability
-  const embeddingService = new EmbeddingService();
+  const embeddingService = getEmbeddingService();
   if (!embeddingService.isAvailable()) {
     const status = embeddingService.getStatus();
     return {

--- a/src/core/knowledge-service.ts
+++ b/src/core/knowledge-service.ts
@@ -159,13 +159,13 @@ export async function searchKnowledgeBase(params: {
   const results = searchResult.data || [];
   const chunks: KnowledgeSearchResultItem[] = results.map((result) => ({
     id: result.id,
-    content: result.payload.content as string,
+    content: (result.payload.content as string) || '',
     score: result.score,
     matchType: 'semantic' as const, // Dense vector search only (BM25 deferred)
-    uri: result.payload.uri as string,
+    uri: (result.payload.uri as string) || '',
     metadata: (result.payload.metadata as Record<string, unknown>) || {},
-    chunkIndex: result.payload.chunkIndex as number,
-    totalChunks: result.payload.totalChunks as number,
+    chunkIndex: (result.payload.chunkIndex as number) ?? 0,
+    totalChunks: (result.payload.totalChunks as number) ?? 0,
     tags: (result.payload.tags as string[]) || [], // PRD #375: AI classification tags
     extractedPolicies: undefined, // Populated by PRD #357
   }));

--- a/src/core/knowledge-service.ts
+++ b/src/core/knowledge-service.ts
@@ -1,0 +1,178 @@
+/**
+ * Knowledge Base Search Service (core layer)
+ *
+ * Provides the reusable `searchKnowledgeBase()` helper used by both the
+ * `manageKnowledge` MCP tool and core consumers (schema recommendation,
+ * operate analysis, REST API). Lives in `core/` so that core modules do not
+ * need to import from the `tools/` layer (avoids a core → tools → core cycle).
+ *
+ * PRD #356: Knowledge Base System
+ * PRD #375: Unified Knowledge Base
+ */
+
+import { invokePluginTool, isPluginInitialized } from './plugin-registry';
+import { EmbeddingService } from './embedding-service';
+import { KnowledgeSearchResultItem } from './knowledge-types';
+
+/**
+ * Plugin providing the vector store operations
+ */
+const PLUGIN_NAME = 'agentic-tools';
+
+/**
+ * Collection name for knowledge base chunks in Qdrant
+ */
+const KNOWLEDGE_COLLECTION = 'knowledge-base';
+
+/**
+ * Default limit for search results
+ */
+const DEFAULT_SEARCH_LIMIT = 20;
+
+/**
+ * Result type for the reusable search function
+ */
+export interface SearchKnowledgeBaseResult {
+  success: boolean;
+  chunks: KnowledgeSearchResultItem[];
+  totalMatches: number;
+  error?: string;
+}
+
+/**
+ * Reusable knowledge base search function.
+ * Can be called from MCP tool handler or HTTP endpoints.
+ *
+ * @param params Search parameters
+ * @returns Search results with chunks or error
+ */
+export async function searchKnowledgeBase(params: {
+  query: string;
+  limit?: number;
+  uriFilter?: string;
+}): Promise<SearchKnowledgeBaseResult> {
+  const { query, limit = DEFAULT_SEARCH_LIMIT, uriFilter } = params;
+
+  // Check plugin availability
+  if (!isPluginInitialized()) {
+    return {
+      success: false,
+      chunks: [],
+      totalMatches: 0,
+      error: 'Plugin system not available',
+    };
+  }
+
+  // Check embedding service availability
+  const embeddingService = new EmbeddingService();
+  if (!embeddingService.isAvailable()) {
+    const status = embeddingService.getStatus();
+    return {
+      success: false,
+      chunks: [],
+      totalMatches: 0,
+      error: `Embedding service not available: ${status.reason}`,
+    };
+  }
+
+  // Generate embedding for the search query
+  const queryEmbedding = await embeddingService.generateEmbedding(query);
+
+  // Build filter if uriFilter is provided
+  let filter: Record<string, unknown> | undefined;
+  if (uriFilter) {
+    filter = {
+      must: [
+        {
+          key: 'uri',
+          match: {
+            value: uriFilter,
+          },
+        },
+      ],
+    };
+  }
+
+  // Call vector_search plugin tool
+  const searchResponse = await invokePluginTool(PLUGIN_NAME, 'vector_search', {
+    collection: KNOWLEDGE_COLLECTION,
+    embedding: queryEmbedding,
+    limit,
+    filter,
+    scoreThreshold: 0, // Return all results up to limit, let consumer filter by score
+  });
+
+  if (!searchResponse.success) {
+    const error = searchResponse.error as { message?: string; error?: string } | undefined;
+    const errorMessage = error?.message || error?.error || 'Search failed';
+
+    // If collection doesn't exist (Not Found), return empty result (not error)
+    if (errorMessage.includes('Not Found') || errorMessage.includes('not found')) {
+      return {
+        success: true,
+        chunks: [],
+        totalMatches: 0,
+      };
+    }
+
+    return {
+      success: false,
+      chunks: [],
+      totalMatches: 0,
+      error: errorMessage,
+    };
+  }
+
+  // Extract results from plugin response
+  const searchResult = searchResponse.result as {
+    success: boolean;
+    data?: Array<{
+      id: string;
+      score: number;
+      payload: Record<string, unknown>;
+    }>;
+    error?: string;
+    message: string;
+  };
+
+  if (!searchResult.success) {
+    const errorMessage = searchResult.error || searchResult.message;
+
+    // If collection doesn't exist, return empty result (not error)
+    if (errorMessage.includes('Not Found') || errorMessage.includes('not found')) {
+      return {
+        success: true,
+        chunks: [],
+        totalMatches: 0,
+      };
+    }
+
+    return {
+      success: false,
+      chunks: [],
+      totalMatches: 0,
+      error: errorMessage,
+    };
+  }
+
+  // Transform results to KnowledgeSearchResultItem format
+  const results = searchResult.data || [];
+  const chunks: KnowledgeSearchResultItem[] = results.map((result) => ({
+    id: result.id,
+    content: result.payload.content as string,
+    score: result.score,
+    matchType: 'semantic' as const, // Dense vector search only (BM25 deferred)
+    uri: result.payload.uri as string,
+    metadata: (result.payload.metadata as Record<string, unknown>) || {},
+    chunkIndex: result.payload.chunkIndex as number,
+    totalChunks: result.payload.totalChunks as number,
+    tags: (result.payload.tags as string[]) || [], // PRD #375: AI classification tags
+    extractedPolicies: undefined, // Populated by PRD #357
+  }));
+
+  return {
+    success: true,
+    chunks,
+    totalMatches: chunks.length,
+  };
+}

--- a/src/core/knowledge-service.ts
+++ b/src/core/knowledge-service.ts
@@ -125,18 +125,27 @@ export async function searchKnowledgeBase(params: {
 
   // Extract results from plugin response
   const searchResult = searchResponse.result as {
-    success: boolean;
+    success?: boolean;
     data?: Array<{
       id: string;
       score: number;
       payload: Record<string, unknown>;
     }>;
     error?: string;
-    message: string;
-  };
+    message?: string;
+  } | null;
+
+  if (!searchResult || typeof searchResult !== 'object') {
+    return {
+      success: false,
+      chunks: [],
+      totalMatches: 0,
+      error: 'Search returned an invalid response',
+    };
+  }
 
   if (!searchResult.success) {
-    const errorMessage = searchResult.error || searchResult.message;
+    const errorMessage = searchResult.error || searchResult.message || 'Search failed';
 
     // If collection doesn't exist, return empty result (not error)
     if (errorMessage.includes('Not Found') || errorMessage.includes('not found')) {

--- a/src/core/knowledge-service.ts
+++ b/src/core/knowledge-service.ts
@@ -17,17 +17,17 @@ import { KnowledgeSearchResultItem } from './knowledge-types';
 /**
  * Plugin providing the vector store operations
  */
-const PLUGIN_NAME = 'agentic-tools';
+export const PLUGIN_NAME = 'agentic-tools';
 
 /**
  * Collection name for knowledge base chunks in Qdrant
  */
-const KNOWLEDGE_COLLECTION = 'knowledge-base';
+export const KNOWLEDGE_COLLECTION = 'knowledge-base';
 
 /**
  * Default limit for search results
  */
-const DEFAULT_SEARCH_LIMIT = 20;
+export const DEFAULT_SEARCH_LIMIT = 20;
 
 let embeddingServiceInstance: EmbeddingService | null = null;
 function getEmbeddingService(): EmbeddingService {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -14,7 +14,7 @@ import { extractJsonFromAIResponse, execAsync } from './platform-utils';
 import { AI_SERVICE_ERROR_TEMPLATES } from './constants';
 import { HelmChartInfo } from './helm-types';
 import { KnowledgeSearchResultItem } from './knowledge-types';
-import { searchKnowledgeBase } from '../tools/manage-knowledge';
+import { searchKnowledgeBase } from './knowledge-service';
 
 // PRD #343: Inline sanitization (helm-utils.ts removed)
 function sanitizeShellArg(arg: string, fieldName: string = 'argument'): string {

--- a/src/interfaces/rest-api.ts
+++ b/src/interfaces/rest-api.ts
@@ -58,7 +58,7 @@ import { invokePluginTool, isPluginInitialized } from '../core/plugin-registry';
 import {
   searchKnowledgeBase,
   type SearchKnowledgeBaseResult,
-} from '../tools/manage-knowledge';
+} from '../core/knowledge-service';
 import type { AITool } from '../core/ai-provider.interface';
 import { createUser, listUsers, deleteUser } from './oauth/user-management';
 import { getCurrentIdentity } from './request-context';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -135,6 +135,9 @@ async function main() {
           process.stderr.write(`Background discovery: Plugin '${plugin.name}' now available with ${plugin.tools.length} tool(s)\n`);
           // Note: Tools are automatically registered via pluginManager's internal maps
           // The version tool will reflect the updated plugin status
+          runKnowledgeMigration(new ConsoleLogger('KnowledgeMigration')).catch((err) => {
+            process.stderr.write(`Knowledge migration (post-discovery) error: ${err instanceof Error ? err.message : String(err)}\n`);
+          });
         });
         pluginManager.startBackgroundDiscovery();
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -135,9 +135,11 @@ async function main() {
           process.stderr.write(`Background discovery: Plugin '${plugin.name}' now available with ${plugin.tools.length} tool(s)\n`);
           // Note: Tools are automatically registered via pluginManager's internal maps
           // The version tool will reflect the updated plugin status
-          runKnowledgeMigration(new ConsoleLogger('KnowledgeMigration')).catch((err) => {
-            process.stderr.write(`Knowledge migration (post-discovery) error: ${err instanceof Error ? err.message : String(err)}\n`);
-          });
+          if (plugin.tools.some((tool) => tool.name === 'vector_store')) {
+            runKnowledgeMigration(new ConsoleLogger('KnowledgeMigration')).catch((err) => {
+              process.stderr.write(`Knowledge migration (post-discovery) error: ${err instanceof Error ? err.message : String(err)}\n`);
+            });
+          }
         });
         pluginManager.startBackgroundDiscovery();
       }

--- a/src/tools/manage-knowledge.ts
+++ b/src/tools/manage-knowledge.ts
@@ -16,13 +16,13 @@ import {
   PluginChunkResult,
   IngestResponse,
   KnowledgeSearchResponse,
-  KnowledgeSearchResultItem,
   DeleteByUriResponse,
 } from '../core/knowledge-types';
 import { getCurrentIdentity } from '../interfaces/request-context';
 import { checkToolAccess } from '../core/rbac';
 import { createAIProvider } from '../core/ai-provider-factory';
 import { loadPrompt } from '../core/shared-prompt-loader';
+import { searchKnowledgeBase } from '../core/knowledge-service';
 
 /**
  * Collection name for knowledge base chunks in Qdrant
@@ -401,154 +401,6 @@ async function handleIngestOperation(
  * Default limit for search results
  */
 const DEFAULT_SEARCH_LIMIT = 20;
-
-/**
- * Result type for the reusable search function
- */
-export interface SearchKnowledgeBaseResult {
-  success: boolean;
-  chunks: KnowledgeSearchResultItem[];
-  totalMatches: number;
-  error?: string;
-}
-
-/**
- * Reusable knowledge base search function.
- * Can be called from MCP tool handler or HTTP endpoints.
- *
- * @param params Search parameters
- * @returns Search results with chunks or error
- */
-export async function searchKnowledgeBase(params: {
-  query: string;
-  limit?: number;
-  uriFilter?: string;
-}): Promise<SearchKnowledgeBaseResult> {
-  const { query, limit = DEFAULT_SEARCH_LIMIT, uriFilter } = params;
-
-  // Check plugin availability
-  if (!isPluginInitialized()) {
-    return {
-      success: false,
-      chunks: [],
-      totalMatches: 0,
-      error: 'Plugin system not available',
-    };
-  }
-
-  // Check embedding service availability
-  const embeddingService = new EmbeddingService();
-  if (!embeddingService.isAvailable()) {
-    const status = embeddingService.getStatus();
-    return {
-      success: false,
-      chunks: [],
-      totalMatches: 0,
-      error: `Embedding service not available: ${status.reason}`,
-    };
-  }
-
-  // Generate embedding for the search query
-  const queryEmbedding = await embeddingService.generateEmbedding(query);
-
-  // Build filter if uriFilter is provided
-  let filter: Record<string, unknown> | undefined;
-  if (uriFilter) {
-    filter = {
-      must: [
-        {
-          key: 'uri',
-          match: {
-            value: uriFilter,
-          },
-        },
-      ],
-    };
-  }
-
-  // Call vector_search plugin tool
-  const searchResponse = await invokePluginTool(PLUGIN_NAME, 'vector_search', {
-    collection: KNOWLEDGE_COLLECTION,
-    embedding: queryEmbedding,
-    limit,
-    filter,
-    scoreThreshold: 0, // Return all results up to limit, let consumer filter by score
-  });
-
-  if (!searchResponse.success) {
-    const error = searchResponse.error as { message?: string; error?: string } | undefined;
-    const errorMessage = error?.message || error?.error || 'Search failed';
-
-    // If collection doesn't exist (Not Found), return empty result (not error)
-    if (errorMessage.includes('Not Found') || errorMessage.includes('not found')) {
-      return {
-        success: true,
-        chunks: [],
-        totalMatches: 0,
-      };
-    }
-
-    return {
-      success: false,
-      chunks: [],
-      totalMatches: 0,
-      error: errorMessage,
-    };
-  }
-
-  // Extract results from plugin response
-  const searchResult = searchResponse.result as {
-    success: boolean;
-    data?: Array<{
-      id: string;
-      score: number;
-      payload: Record<string, unknown>;
-    }>;
-    error?: string;
-    message: string;
-  };
-
-  if (!searchResult.success) {
-    const errorMessage = searchResult.error || searchResult.message;
-
-    // If collection doesn't exist, return empty result (not error)
-    if (errorMessage.includes('Not Found') || errorMessage.includes('not found')) {
-      return {
-        success: true,
-        chunks: [],
-        totalMatches: 0,
-      };
-    }
-
-    return {
-      success: false,
-      chunks: [],
-      totalMatches: 0,
-      error: errorMessage,
-    };
-  }
-
-  // Transform results to KnowledgeSearchResultItem format
-  const results = searchResult.data || [];
-  const chunks: KnowledgeSearchResultItem[] = results.map((result) => ({
-    id: result.id,
-    content: result.payload.content as string,
-    score: result.score,
-    matchType: 'semantic' as const, // Dense vector search only (BM25 deferred)
-    uri: result.payload.uri as string,
-    metadata: (result.payload.metadata as Record<string, unknown>) || {},
-    chunkIndex: result.payload.chunkIndex as number,
-    totalChunks: result.payload.totalChunks as number,
-    tags: (result.payload.tags as string[]) || [],  // PRD #375: AI classification tags
-    extractedPolicies: undefined, // Populated by PRD #357
-  }));
-
-  return {
-    success: true,
-    chunks,
-    totalMatches: chunks.length,
-  };
-}
 
 /**
  * Handle the search operation (MCP tool handler)

--- a/src/tools/manage-knowledge.ts
+++ b/src/tools/manage-knowledge.ts
@@ -22,12 +22,12 @@ import { getCurrentIdentity } from '../interfaces/request-context';
 import { checkToolAccess } from '../core/rbac';
 import { createAIProvider } from '../core/ai-provider-factory';
 import { loadPrompt } from '../core/shared-prompt-loader';
-import { searchKnowledgeBase } from '../core/knowledge-service';
-
-/**
- * Collection name for knowledge base chunks in Qdrant
- */
-const KNOWLEDGE_COLLECTION = 'knowledge-base';
+import {
+  searchKnowledgeBase,
+  PLUGIN_NAME,
+  KNOWLEDGE_COLLECTION,
+  DEFAULT_SEARCH_LIMIT,
+} from '../core/knowledge-service';
 
 /**
  * Valid classification tags for document content
@@ -154,11 +154,6 @@ export interface ManageKnowledgeInput {
   uriFilter?: string;
   interaction_id?: string;
 }
-
-/**
- * Plugin name for agentic-tools
- */
-const PLUGIN_NAME = 'agentic-tools';
 
 /**
  * Create error response matching other tool patterns
@@ -396,11 +391,6 @@ async function handleIngestOperation(
     });
   }
 }
-
-/**
- * Default limit for search results
- */
-const DEFAULT_SEARCH_LIMIT = 20;
 
 /**
  * Handle the search operation (MCP tool handler)

--- a/src/tools/operate.ts
+++ b/src/tools/operate.ts
@@ -286,7 +286,7 @@ export function formatKnowledgeContext(chunks: KnowledgeSearchResultItem[]): str
       : 'General';
     formatted += `### Knowledge ${index + 1} [${typeLabel}]\n\n`;
     formatted += `**Source:** ${chunk.uri}\n\n`;
-    formatted += chunk.content + '\n\n';
+    formatted += (chunk.content.length > 300 ? chunk.content.substring(0, 300) + '...' : chunk.content) + '\n\n';
     if (index < chunks.length - 1) {
       formatted += '---\n\n';
     }

--- a/src/tools/operate.ts
+++ b/src/tools/operate.ts
@@ -16,7 +16,7 @@ import { getCurrentIdentity } from '../interfaces/request-context';
 import { checkToolAccess } from '../core/rbac';
 import { CapabilityVectorService } from '../core/capability-vector-service';
 import { KnowledgeSearchResultItem } from '../core/knowledge-types';
-import { searchKnowledgeBase } from './manage-knowledge';
+import { searchKnowledgeBase } from '../core/knowledge-service';
 import { ResourceCapability } from '../core/capabilities';
 import { BaseVisualizationData } from '../core/visualization';
 import { buildAgentDisplayBlock } from '../core/index';

--- a/src/tools/organizational-data.ts
+++ b/src/tools/organizational-data.ts
@@ -27,12 +27,12 @@ import { checkToolAccess } from '../core/rbac';
 // Organizational knowledge is now managed via manageKnowledge (ingest/search/deleteByUri).
 // This tool is now capabilities-only.
 export const ORGANIZATIONAL_DATA_TOOL_NAME = 'manageOrgData';
-export const ORGANIZATIONAL_DATA_TOOL_DESCRIPTION = 'Tool for managing cluster resource capabilities. Supports scan, list, get, delete, deleteAll, and progress operations for cluster resource capability discovery and management. Use dataType="capabilities" to manage cluster capabilities. NOTE: Organizational patterns and policies are now managed via manageKnowledge tool (ingest documents, search, deleteByUri) with automatic AI classification.';
+export const ORGANIZATIONAL_DATA_TOOL_DESCRIPTION = 'Tool for managing cluster resource capabilities. Supports scan, list, get, search, delete, deleteAll, and progress operations for cluster resource capability discovery and management. Use dataType="capabilities" to manage cluster capabilities. NOTE: Organizational patterns and policies are now managed via manageKnowledge tool (ingest documents, search, deleteByUri) with automatic AI classification.';
 
 // Schema - capabilities only (PRD #375: pattern/policy removed from this tool)
 export const ORGANIZATIONAL_DATA_TOOL_INPUT_SCHEMA = {
   dataType: z.enum(['capabilities']).describe('Type of cluster data to manage: "capabilities" for resource capabilities. (Note: organizational knowledge/patterns/policies are managed via manageKnowledge tool)'),
-  operation: z.enum(['list', 'get', 'delete', 'deleteAll', 'scan', 'analyze', 'progress', 'search']).describe('Operation to perform on the cluster data'),
+  operation: z.enum(['list', 'get', 'delete', 'deleteAll', 'scan', 'progress', 'search']).describe('Operation to perform on the cluster data'),
 
   // Workflow fields for step-by-step capability scanning
   sessionId: z.string().optional().describe('Session ID (required for continuing workflow steps, optional for progress - uses latest session if omitted)'),
@@ -69,7 +69,7 @@ export const ORGANIZATIONAL_DATA_TOOL_INPUT_SCHEMA = {
  */
 export interface OrganizationalDataInput {
   dataType: 'capabilities';
-  operation: 'list' | 'get' | 'delete' | 'deleteAll' | 'scan' | 'analyze' | 'progress' | 'search';
+  operation: 'list' | 'get' | 'delete' | 'deleteAll' | 'scan' | 'progress' | 'search';
   sessionId?: string;
   step?: string;
   response?: string;
@@ -907,5 +907,3 @@ export async function handleOrganizationalDataTool(
     };
   }
 }
-
-

--- a/tests/integration/tools/manage-knowledge.test.ts
+++ b/tests/integration/tools/manage-knowledge.test.ts
@@ -12,7 +12,7 @@ import { IntegrationTest } from '../helpers/test-base.js';
 import { v5 as uuidv5 } from 'uuid';
 
 // Same namespace used by the plugin for deterministic chunk IDs
-const KNOWLEDGE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const KNOWLEDGE_NAMESPACE = uuidv5.DNS;
 
 describe.concurrent('ManageKnowledge Integration', () => {
   const integrationTest = new IntegrationTest();

--- a/tests/integration/tools/unified-knowledge-base.test.ts
+++ b/tests/integration/tools/unified-knowledge-base.test.ts
@@ -53,7 +53,7 @@ describe.concurrent('PRD #375 Unified Knowledge Base - Migration & E2E', () => {
   // Milestone 6: E2E — ingest → classify → search → verify tags in results
   // -------------------------------------------------------------------------
 
-  describe('E2E: Ingest, Classification, and Search', () => {
+  describe.concurrent('E2E: Ingest, Classification, and Search', () => {
     test(
       'should classify policy document and return tags in search results',
       async () => {
@@ -284,7 +284,7 @@ describe.concurrent('PRD #375 Unified Knowledge Base - Migration & E2E', () => {
   // knowledge with tags
   // -------------------------------------------------------------------------
 
-  describe('E2E: Consumer Tools See Unified Knowledge', () => {
+  describe.concurrent('E2E: Consumer Tools See Unified Knowledge', () => {
     test(
       'should allow operate tool to find context from unified knowledge base',
       async () => {
@@ -359,7 +359,7 @@ describe.concurrent('PRD #375 Unified Knowledge Base - Migration & E2E', () => {
   // failing.
   // -------------------------------------------------------------------------
 
-  describe('Migration: Legacy patterns → Unified knowledge base', () => {
+  describe.concurrent('Migration: Legacy patterns → Unified knowledge base', () => {
     const seedMarker = process.env.MIGRATION_SEED_MARKER;
     const seedId = process.env.MIGRATION_SEED_ID;
 

--- a/tests/unit/core/knowledge-migration.test.ts
+++ b/tests/unit/core/knowledge-migration.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { v5 as uuidv5 } from 'uuid';
 
 // Must be hoisted before the import that depends on it.
 vi.mock('../../../src/core/plugin-registry', () => ({
@@ -18,7 +19,7 @@ vi.mock('../../../src/core/plugin-registry', () => ({
   invokePluginTool: vi.fn(),
 }));
 
-import { runKnowledgeMigration, LEGACY_LIST_CAP } from '../../../src/core/knowledge-migration.js';
+import { runKnowledgeMigration, LEGACY_LIST_CAP, KNOWLEDGE_NAMESPACE } from '../../../src/core/knowledge-migration.js';
 import { isPluginInitialized, invokePluginTool } from '../../../src/core/plugin-registry.js';
 import type { Logger } from '../../../src/core/error-handling.js';
 
@@ -149,7 +150,7 @@ describe('runKnowledgeMigration', () => {
 
     expect(captured[0]).toMatchObject({
       collection: 'knowledge-base',
-      id: 'pattern-abc',
+      id: uuidv5('legacy://patterns/pattern-abc#0', KNOWLEDGE_NAMESPACE),
       embedding: FAKE_VECTOR,
     });
     expect(captured[0]).not.toHaveProperty('vector');


### PR DESCRIPTION
Addresses the remaining review items from https://github.com/vfarcic/dot-ai/pull/611#issuecomment-4929292495.

Regarding the re-run hook of knowledge migration, I'm not sure whether the approach I went with is worth it.
As of now, the callback simply re-runs the migration whenever any pending plugin comes online. While the migration should be idempotent, this introduces additional "noise" and the migration might potentially run-run a couple of times.
Also gating the hook with the plugin name requires a string contant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified semantic knowledge-base search with optional URI filtering and safe empty results when the knowledge collection isn’t found.
  * Added automated knowledge migration triggered by newly available vector-store plugins, using deterministic identifiers for stable retrieval.
* **Improvements**
  * Knowledge context now truncates each chunk to 300 characters for more focused responses.
  * Prevents overlapping migration runs and normalizes “not found” search outcomes consistently.
  * Organizational data capabilities no longer include the `analyze` operation.
* **Tests**
  * Updated E2E/migration suites to run concurrently.
* **Chores**
  * Moved `uuid` from development-only dependencies to runtime dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->