### PR TITLE
fix: Fix deployment image tag in Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from the non-existent 'v999-nonexistent' to 'latest' will allow kubelet to successfully pull the image and start the container. Argo CD's automated sync will automatically apply this change to the cluster.

**Risk Level:** low