### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from 'nginx:v999-nonexistent' (non-existent) to 'nginx:latest' (valid, well-known image) resolves the ImagePullBackOff error. ArgoCD will automatically detect the change and sync it.

**Risk Level:** low