### PR TITLE
fix: Fix the image tag in the deployment.yaml manifest from invalid 'nginx:v999-nonexistent' to valid 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Using 'nginx:latest' provides a valid, stable image that exists in the Docker registry. Argo CD will automatically sync this change to the cluster with its configured automated sync policy.

**Risk Level:** low