### PR TITLE
fix: Fix container image tag in deployment manifest to use valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag v999-nonexistent does not exist in Docker registry. Changing to nginx:latest (a valid, stable image) allows the kubelet to successfully pull the image and start the container. Argo CD's automated sync policy will detect and apply this change automatically.

**Risk Level:** low