### PR TITLE
fix: Update deployment image tag to valid nginx:latest in Git repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag to 'nginx:latest' resolves the ImagePullBackOff error by using a valid, existing image. Argo CD will automatically sync this change due to the enabled auto-sync policy.

**Risk Level:** low