### PR TITLE
feat: add AWS credential provider chain for Bedrock

### DIFF
--- a/changelog.d/694.feature.md
+++ b/changelog.d/694.feature.md
@@ -1,0 +1,7 @@
+## Secretless Amazon Bedrock Authentication
+
+Amazon Bedrock now authenticates through the standard AWS credential provider chain, so dot-ai can run on EKS with no static AWS access keys. Previously the Bedrock provider only read `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` directly from the environment, forcing operators to inject long-lived keys and rotate them manually — secretless mechanisms like EKS Pod Identity and IRSA simply did not work.
+
+Both the LLM and the Bedrock (Titan) embeddings paths now resolve credentials via `fromNodeProviderChain()`, which walks environment variables, shared AWS config/credentials files, IRSA web-identity tokens, EKS Pod Identity / container credentials, and EC2 instance metadata (IMDS). Short-lived IRSA and Pod Identity credentials are refreshed automatically on each request, so multi-hour sessions keep working without pod restarts. Existing setups are unaffected: static environment-variable keys are still checked first, and bearer-token auth (`AWS_BEARER_TOKEN_BEDROCK`) continues to take precedence.
+
+Set `AI_PROVIDER=amazon_bedrock` and provide a region via `AWS_REGION` (defaults to `us-east-1`). On EKS, associate an IAM role with the pod's ServiceAccount through Pod Identity or IRSA — no static credentials required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/openai-compatible": "^2.0.35",
         "@ai-sdk/xai": "^3.0.67",
+        "@aws-sdk/credential-providers": "^3.1091.0",
         "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.0",
         "@kubernetes/client-node": "^1.3.0",
@@ -397,55 +398,300 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.58.tgz",
+      "integrity": "sha512-s5uoABv5eOzuH/S+XngHjHSrY8mK0UTBUFs8pm1ynBNuxXmYp176zarDyxN9lUS3Rry0wjzNvJUV09QROaO98g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1091.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1091.0.tgz",
+      "integrity": "sha512-lPX4DF7wJ5Zjlgwk7MIJys36Dum3vsqAweVRVQjWtfbL7+fD0fwNxrRivYlNddD/PPCNJnOzMHlcEEhc1CVNRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.58",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -2169,13 +2415,26 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "version": "3.29.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
+      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.11.tgz",
+      "integrity": "sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2195,41 +2454,58 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.8.tgz",
+      "integrity": "sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.8.tgz",
+      "integrity": "sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.7.tgz",
+      "integrity": "sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
@@ -3513,6 +3789,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3767,21 +3767,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3797,9 +3810,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5713,9 +5726,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -5726,6 +5739,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6795,9 +6809,10 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.4.tgz",
-      "integrity": "sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/openai-compatible": "^2.0.35",
     "@ai-sdk/xai": "^3.0.67",
+    "@aws-sdk/credential-providers": "^3.1091.0",
     "@grpc/grpc-js": "^1.14.4",
     "@grpc/proto-loader": "^0.8.0",
     "@kubernetes/client-node": "^1.3.0",

--- a/prds/694-bedrock-aws-credential-chain.md
+++ b/prds/694-bedrock-aws-credential-chain.md
@@ -98,9 +98,16 @@ Optional (general flexibility, not the headline auth story): add `extraVolumes`/
 - [ ] **M4 — Documentation.** EKS Pod Identity + IRSA setup in `docs/ai-engine/setup/deployment.md`; correct the "AWS credentials" rows to distinguish static keys vs secretless workload identity. Changelog fragment in `changelog.d/`.
 - [ ] **M5 — Validation.** Validate Bedrock generation + embeddings against real credentials (env-var path locally / via CI; secretless path validated on EKS or documented as operator-verified).
 
-## Open Questions (for the issue author / maintainer)
+## Confirmed decisions
 
 1. **Which secretless mechanism** do you target — EKS Pod Identity, IRSA, or both? (The fix covers both; this shapes what we validate and document first.)
+Both. Pod Identity is our long-term target (zero secrets, native IAM), but IRSA is the interim path we are already deploying while the fromNodeProviderChain() fix is pending. Supporting both in the same credential chain means we can transition without a second code change.
+
 2. **Do you need Bedrock embeddings** (Titan) under the same workload identity, or only the LLM? (Determines whether M-embeddings validation is required or nice-to-have.)
+Nice-to-have, not required. Our current plan uses local embeddings (HuggingFace TEI, zero-config), so the LLM path is the priority. Titan embeddings under the same workload identity would be a welcome addition but not a blocker.
+
 3. **Is secretless sufficient**, or do you also need a mounted `~/.aws/credentials`/`~/.aws/config` Secret (e.g. for a `credential_process` or SSO profile)? That's what would justify the optional `extraVolumes` work.
+Secretless is sufficient for our production deployment. However, I can see a use case where someone running dot-ai locally (e.g., on kind with a static token) would want to inject AWS credentials via a mounted Secret or environment variables. Since fromNodeProviderChain() falls back to env vars (AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN) when no Pod Identity or IRSA is present, this should work out of the box with no extra configuration — which is ideal.
+
 4. **Region**: set via existing `extraEnv` (`AWS_REGION`), or would a dedicated `ai.aws.region` chart value be preferable?
+Yes, extraEnv is perfectly fine. No need for a dedicated ai.aws.region value.

--- a/src/core/embedding-service.ts
+++ b/src/core/embedding-service.ts
@@ -6,6 +6,7 @@
  */
 
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { google } from '@ai-sdk/google';
 import { createOpenAI } from '@ai-sdk/openai';
 import { embed, embedMany, EmbeddingModel } from 'ai';
@@ -113,7 +114,9 @@ export class VercelEmbeddingProvider implements EmbeddingProvider {
         this.dimensions = config.dimensions || 768;
         break;
       case 'amazon_bedrock':
-        // AWS SDK handles credentials automatically - no API key needed
+        // PRD #694: Credentials are resolved through the explicit
+        // credentialProvider (fromNodeProviderChain), not automatically.
+        // No static API key is needed for secretless EKS auth.
         this.apiKey = 'bedrock-uses-aws-credentials';
         this.model =
           config.model ||
@@ -146,12 +149,12 @@ export class VercelEmbeddingProvider implements EmbeddingProvider {
           this.modelInstance = google.textEmbedding(this.model);
           break;
         case 'amazon_bedrock': {
-          // AWS SDK automatically uses credential chain:
-          // 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION)
-          // 2. ~/.aws/credentials file
-          // 3. IAM roles (EC2 instance profiles, ECS roles, EKS service accounts)
+          // PRD #694: Explicit credentialProvider enables secretless auth.
+          // fromNodeProviderChain() supports env vars, shared config, IRSA
+          // web-identity, EKS Pod Identity / container credentials, and IMDS.
           const bedrock = createAmazonBedrock({
             region: process.env.AWS_REGION || 'us-east-1',
+            credentialProvider: fromNodeProviderChain(),
           });
           this.modelInstance = bedrock.textEmbeddingModel(this.model);
           break;

--- a/src/core/providers/vercel-provider.ts
+++ b/src/core/providers/vercel-provider.ts
@@ -14,6 +14,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createXai } from '@ai-sdk/xai';
 import { createAlibaba } from '@ai-sdk/alibaba';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { AI_SERVICE_ERROR_TEMPLATES } from '../constants';
 import {
@@ -226,14 +227,22 @@ export class VercelProvider implements AIProvider {
           this.modelInstance = provider.chatModel(this.model);
           return; // Early return - model instance already set
         case 'amazon_bedrock':
-          // PRD #175: Amazon Bedrock provider
-          // AWS SDK automatically uses credential chain:
-          // 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION)
-          // 2. ~/.aws/credentials file
-          // 3. IAM roles (EC2 instance profiles, ECS roles, EKS service accounts)
-          // Note: Custom headers not supported - AWS SDK handles auth via credential chain
+          // PRD #694: Amazon Bedrock provider with explicit credential chain.
+          // @ai-sdk/amazon-bedrock does NOT automatically walk the standard AWS
+          // credential chain. The credentialProvider option is the only hook that
+          // enables secretless authentication (IRSA, EKS Pod Identity, IMDS, etc.).
+          // fromNodeProviderChain() is supplied explicitly and supports:
+          //   - environment credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+          //     AWS_SESSION_TOKEN);
+          //   - shared AWS configuration (~/.aws/credentials, ~/.aws/config);
+          //   - IRSA web-identity token (AWS_WEB_IDENTITY_TOKEN_FILE, AWS_ROLE_ARN);
+          //   - EKS Pod Identity / AWS_CONTAINER_CREDENTIALS_FULL_URI;
+          //   - EC2 instance metadata (IMDS).
+          // Custom headers are not supported — AWS SDK handles auth via the
+          // credential chain or bearer token.
           provider = createAmazonBedrock({
             region: process.env.AWS_REGION || 'us-east-1',
+            credentialProvider: fromNodeProviderChain(),
           });
           break;
         case 'openrouter':

--- a/tests/unit/core/embedding-service.bedrock.test.ts
+++ b/tests/unit/core/embedding-service.bedrock.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the Amazon Bedrock credential-provider integration in
+ * VercelEmbeddingProvider (PRD #694).
+ *
+ * Strategy: mock @ai-sdk/amazon-bedrock and @aws-sdk/credential-providers so
+ * we can assert that fromNodeProviderChain() is wired into
+ * createAmazonBedrock({ credentialProvider }) on the embeddings path.
+ * Follows the vi.hoisted pattern from embedding-service.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMockEmbeddingModel } from './_helpers/mock-embedding-model';
+
+// Hoisted mocks — factories run before module imports.
+const { mockCreateAmazonBedrock, mockFromNodeProviderChain } =
+  vi.hoisted(() => ({
+    mockCreateAmazonBedrock: vi.fn(),
+    mockFromNodeProviderChain: vi.fn(),
+  }));
+
+vi.mock('@ai-sdk/amazon-bedrock', () => ({
+  createAmazonBedrock: mockCreateAmazonBedrock,
+}));
+
+vi.mock('@aws-sdk/credential-providers', () => ({
+  fromNodeProviderChain: mockFromNodeProviderChain,
+}));
+
+// Stub tracing so it doesn't interfere.
+vi.mock('../../../src/core/tracing/ai-tracing', () => ({
+  withAITracing: vi.fn((_config, fn) => fn()),
+}));
+
+import { VercelEmbeddingProvider } from '../../../src/core/embedding-service';
+
+describe('VercelEmbeddingProvider — Amazon Bedrock credential chain (PRD #694)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.DEBUG_DOT_AI;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('passes credentialProvider from fromNodeProviderChain() to createAmazonBedrock', () => {
+    const sentinelProvider = Symbol('credential-provider');
+    const mockModel = createMockEmbeddingModel({ dimensions: 4 });
+
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue({
+      textEmbeddingModel: () => mockModel,
+    });
+
+    const provider = new VercelEmbeddingProvider({
+      provider: 'amazon_bedrock',
+    });
+
+    expect(provider).toBeDefined();
+    expect(provider.isAvailable()).toBe(true);
+    expect(mockFromNodeProviderChain).toHaveBeenCalledOnce();
+    expect(mockCreateAmazonBedrock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialProvider: sentinelProvider,
+      }),
+    );
+  });
+
+  it('defaults region to us-east-1 when AWS_REGION is not set', () => {
+    const sentinelProvider = Symbol('credential-provider');
+    const mockModel = createMockEmbeddingModel({ dimensions: 4 });
+
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue({
+      textEmbeddingModel: () => mockModel,
+    });
+
+    new VercelEmbeddingProvider({
+      provider: 'amazon_bedrock',
+    });
+
+    expect(mockCreateAmazonBedrock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'us-east-1',
+        credentialProvider: sentinelProvider,
+      }),
+    );
+  });
+
+  it('respects AWS_REGION environment variable', () => {
+    process.env.AWS_REGION = 'eu-west-1';
+    const sentinelProvider = Symbol('credential-provider');
+    const mockModel = createMockEmbeddingModel({ dimensions: 4 });
+
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue({
+      textEmbeddingModel: () => mockModel,
+    });
+
+    new VercelEmbeddingProvider({
+      provider: 'amazon_bedrock',
+    });
+
+    expect(mockCreateAmazonBedrock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'eu-west-1',
+        credentialProvider: sentinelProvider,
+      }),
+    );
+  });
+
+  it('constructs without static AWS credentials', () => {
+    const sentinelProvider = Symbol('credential-provider');
+    const mockModel = createMockEmbeddingModel({ dimensions: 4 });
+
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue({
+      textEmbeddingModel: () => mockModel,
+    });
+
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_SESSION_TOKEN;
+
+    const provider = new VercelEmbeddingProvider({
+      provider: 'amazon_bedrock',
+    });
+
+    expect(provider).toBeDefined();
+    expect(provider.isAvailable()).toBe(true);
+  });
+
+  it('does not call fromNodeProviderChain for non-bedrock providers', () => {
+    const mockModel = createMockEmbeddingModel({ dimensions: 4 });
+
+    // No bedrock mock setup needed — the openai path should not touch bedrock
+    const fakeOpenAI = {
+      textEmbedding: () => mockModel,
+    };
+
+    // We need to mock createOpenAI since the import is also mocked above
+    // We can use vi.mock for this, but for simplicity we can just setup
+    // the bedrock mock and ensure fromNodeProviderChain is NOT called
+    mockFromNodeProviderChain.mockReturnValue('unused');
+    mockCreateAmazonBedrock.mockReturnValue({
+      textEmbeddingModel: () => mockModel,
+    });
+
+    // Create an openai provider instead — use the bedrock mock as a sentinel
+    // to verify it was not invoked.
+    const provider = new VercelEmbeddingProvider({
+      provider: 'amazon_bedrock',
+    });
+
+    expect(provider).toBeDefined();
+    // fromNodeProviderChain should be called for bedrock
+    expect(mockFromNodeProviderChain).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/core/embedding-service.bedrock.test.ts
+++ b/tests/unit/core/embedding-service.bedrock.test.ts
@@ -138,29 +138,15 @@ describe('VercelEmbeddingProvider — Amazon Bedrock credential chain (PRD #694)
   });
 
   it('does not call fromNodeProviderChain for non-bedrock providers', () => {
-    const mockModel = createMockEmbeddingModel({ dimensions: 4 });
+    delete process.env.OPENAI_API_KEY;
 
-    // No bedrock mock setup needed — the openai path should not touch bedrock
-    const fakeOpenAI = {
-      textEmbedding: () => mockModel,
-    };
-
-    // We need to mock createOpenAI since the import is also mocked above
-    // We can use vi.mock for this, but for simplicity we can just setup
-    // the bedrock mock and ensure fromNodeProviderChain is NOT called
-    mockFromNodeProviderChain.mockReturnValue('unused');
-    mockCreateAmazonBedrock.mockReturnValue({
-      textEmbeddingModel: () => mockModel,
-    });
-
-    // Create an openai provider instead — use the bedrock mock as a sentinel
-    // to verify it was not invoked.
     const provider = new VercelEmbeddingProvider({
-      provider: 'amazon_bedrock',
+      provider: 'openai',
     });
 
     expect(provider).toBeDefined();
-    // fromNodeProviderChain should be called for bedrock
-    expect(mockFromNodeProviderChain).toHaveBeenCalledOnce();
+    expect(provider.isAvailable()).toBe(false);
+    expect(mockFromNodeProviderChain).not.toHaveBeenCalled();
+    expect(mockCreateAmazonBedrock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/core/providers/vercel-provider.bedrock.test.ts
+++ b/tests/unit/core/providers/vercel-provider.bedrock.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the Amazon Bedrock credential-provider integration in
+ * VercelProvider (PRD #694).
+ *
+ * Strategy: mock @ai-sdk/amazon-bedrock and @aws-sdk/credential-providers so
+ * we can assert that fromNodeProviderChain() is wired into
+ * createAmazonBedrock({ credentialProvider }) without any real AWS calls.
+ * Follows the vi.hoisted pattern from custom-headers-base-url.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createMockLanguageModel,
+} from './_helpers/mock-language-model';
+
+// Hoisted mocks — factories run before module imports.
+const { mockCreateAmazonBedrock, mockFromNodeProviderChain } =
+  vi.hoisted(() => ({
+    mockCreateAmazonBedrock: vi.fn(),
+    mockFromNodeProviderChain: vi.fn(),
+  }));
+
+vi.mock('@ai-sdk/amazon-bedrock', () => ({
+  createAmazonBedrock: mockCreateAmazonBedrock,
+}));
+
+vi.mock('@aws-sdk/credential-providers', () => ({
+  fromNodeProviderChain: mockFromNodeProviderChain,
+}));
+
+// Stub tracing and debug utils so they don't interfere.
+vi.mock('../../../../src/core/tracing/ai-tracing', () => ({
+  withAITracing: vi.fn((_config, fn) => fn()),
+}));
+
+vi.mock('../../../../src/core/providers/provider-debug-utils', () => ({
+  generateDebugId: vi.fn(() => 'debug-id'),
+  debugLogInteraction: vi.fn(),
+  debugLogPromptOnly: vi.fn(),
+  createAndLogAgenticResult: vi.fn(),
+  logEvaluationDataset: vi.fn(),
+}));
+
+import { VercelProvider } from '../../../../src/core/providers/vercel-provider';
+
+/**
+ * Create a provider factory function that returns a mock model when called.
+ */
+function bedrockProviderFactory() {
+  const mockModel = createMockLanguageModel({ text: 'bedrock response' });
+  const providerFn = vi.fn().mockReturnValue(mockModel);
+  return providerFn;
+}
+
+describe('VercelProvider — Amazon Bedrock credential chain (PRD #694)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.DEBUG_DOT_AI;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('passes credentialProvider from fromNodeProviderChain() to createAmazonBedrock', () => {
+    const sentinelProvider = Symbol('credential-provider');
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue(bedrockProviderFactory());
+
+    const provider = new VercelProvider({
+      provider: 'amazon_bedrock',
+      apiKey: 'ignored-for-bedrock',
+      debugMode: false,
+    });
+
+    expect(provider).toBeDefined();
+    expect(mockFromNodeProviderChain).toHaveBeenCalledOnce();
+    expect(mockCreateAmazonBedrock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialProvider: sentinelProvider,
+      }),
+    );
+  });
+
+  it('defaults region to us-east-1 when AWS_REGION is not set', () => {
+    const sentinelProvider = Symbol('credential-provider');
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue(bedrockProviderFactory());
+
+    new VercelProvider({
+      provider: 'amazon_bedrock',
+      apiKey: 'ignored-for-bedrock',
+      debugMode: false,
+    });
+
+    expect(mockCreateAmazonBedrock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'us-east-1',
+        credentialProvider: sentinelProvider,
+      }),
+    );
+  });
+
+  it('respects AWS_REGION environment variable', () => {
+    process.env.AWS_REGION = 'eu-central-1';
+    const sentinelProvider = Symbol('credential-provider');
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue(bedrockProviderFactory());
+
+    new VercelProvider({
+      provider: 'amazon_bedrock',
+      apiKey: 'ignored-for-bedrock',
+      debugMode: false,
+    });
+
+    expect(mockCreateAmazonBedrock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'eu-central-1',
+        credentialProvider: sentinelProvider,
+      }),
+    );
+  });
+
+  it('does not require static AWS credentials at construction', () => {
+    const sentinelProvider = Symbol('credential-provider');
+    mockFromNodeProviderChain.mockReturnValue(sentinelProvider);
+    mockCreateAmazonBedrock.mockReturnValue(bedrockProviderFactory());
+
+    // Clear all AWS credential env vars
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_SESSION_TOKEN;
+
+    const provider = new VercelProvider({
+      provider: 'amazon_bedrock',
+      apiKey: 'ignored-for-bedrock',
+      debugMode: false,
+    });
+
+    expect(provider).toBeDefined();
+    expect(provider.isInitialized()).toBe(true);
+  });
+
+  it('constructs the credential provider once, not per-request', () => {
+    mockFromNodeProviderChain.mockReturnValue('memoized-provider');
+    mockCreateAmazonBedrock.mockReturnValue(bedrockProviderFactory());
+
+    new VercelProvider({
+      provider: 'amazon_bedrock',
+      apiKey: 'ignored-for-bedrock',
+      debugMode: false,
+    });
+
+    expect(mockFromNodeProviderChain).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the standard AWS SDK credential provider chain for Amazon Bedrock.

This enables secretless authentication through both EKS Pod Identity and IRSA,
while preserving environment-based credentials for local development.

## Changes

- Updated PRD #694 with the confirmed requirements.
- Added `fromNodeProviderChain()` to the Bedrock LLM path.
- Added the same provider-chain support to the optional Bedrock embeddings path.
- Added `@aws-sdk/credential-providers`.
- Corrected the misleading credential-chain comments.
- Added focused unit tests for both Bedrock paths.

## Validation

- `npm run test:unit`
  - 637 passed
  - 3 skipped
- `npm run lint`
  - passed
- `npm run build`
  - passed
- `git diff --check`
  - passed

The tests use mocks and do not perform real AWS or Bedrock API calls.
No static AWS credentials are required.

Relates to #694.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled secretless Amazon Bedrock authentication by using the AWS credential provider chain (supports workload identity and instance metadata) with no need for static AWS credentials.
  * Bedrock region selection now defaults to `us-east-1` when `AWS_REGION` is unset, or uses the provided `AWS_REGION`.

* **Documentation**
  * Updated the Bedrock/AWS authentication, embeddings, credential mounting, and region configuration guidance with confirmed decisions.

* **Tests**
  * Added unit tests validating credential-provider wiring, region behavior, and operation without static AWS credential environment variables.

* **Chores**
  * Added an AWS credential providers dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->