### PR TITLE
fix: Fix image tag in deployment manifest from invalid 'nginx:v999-nonexistent' to valid 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Updating to a valid existing image allows kubelet to successfully pull the image and start the pod. Using nginx:latest is a stable, well-maintained image available in Docker Hub. Argo CD's auto-sync policy will automatically reconcile the change once committed.

**Risk Level:** low