### PR TITLE
fix: Fix the invalid nginx image tag in deployment.yaml from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Using 'nginx:latest' provides a valid, publicly available image that can be pulled from Docker Hub. Argo CD's automated sync policy will detect the change and reconcile the deployment automatically.

**Risk Level:** low