### PR TITLE
fix: Fix image tag in deployment manifest from invalid 'nginx:v999-nonexistent' to valid 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The non-existent image tag is causing the ImagePullBackOff error. Changing to a valid, stable nginx:latest image allows the kubelet to successfully pull the image and start the pod. ArgoCD is configured with automated sync and self-heal, so the change will be applied automatically.

**Risk Level:** low