### PR TITLE
fix: Update the deployment image from invalid tag to valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag is the root cause of the ImagePullBackOff error. Changing to 'nginx:latest' provides a valid, stable image that can be successfully pulled. Argo CD will automatically detect and apply this change due to the configured automated sync policy.

**Risk Level:** low