### PR TITLE
fix: Update deployment.yaml to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:stable
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'nginx:v999-nonexistent' is invalid and will never succeed. Changing to 'nginx:stable' provides a stable, valid image that exists in Docker Hub. Once the Git source is updated, Argo CD's auto-sync will immediately deploy the fix.

**Risk Level:** low