### PR TITLE
fix: Update deployment.yaml to use valid nginx image tag 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from the non-existent 'v999-nonexistent' to 'latest' provides a valid, stable nginx image. Argo CD will automatically detect the change in Git and sync it to the cluster due to the configured automated sync policy.

**Risk Level:** low