### PR TITLE
fix: Fix image tag in deployment.yaml from 'nginx:v999-nonexistent' to 'nginx:1.27.0'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:1.27.0
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing to a valid, existing nginx image tag allows the container to be pulled and started successfully. Argo CD will automatically sync this change due to configured auto-sync policy.

**Risk Level:** low