### PR TITLE
fix: Fix invalid nginx image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag from 'nginx:v999-nonexistent' to 'nginx:latest' (or another valid version) allows the kubelet to successfully pull the image and start the container. ArgoCD's automatic sync policy will detect the source change and apply it to the cluster.

**Risk Level:** low