### PR TITLE
fix: Update image tag from 'nginx:v999-nonexistent' to 'nginx:latest' in deployment.yaml

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The current tag 'v999-nonexistent' is invalid and cannot be pulled from Docker registry. Changing to 'nginx:latest' provides a valid, stable image. Once committed to Git, Argo CD's automated sync will apply the change automatically.

**Risk Level:** low