### PR TITLE
fix: Update the deployment manifest in the source repository to use a valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' provides a valid, existing image that kubelet can successfully pull. ArgoCD will automatically detect the change and sync it to the cluster due to the automated sync policy.

**Risk Level:** low