### PR TITLE
fix: Fix image tag in deployment manifest from v999-nonexistent to latest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to a valid, existing version (nginx:latest) allows the kubelet to successfully pull the image and start the container. Argo CD will automatically detect the Git change and resync the deployment.

**Risk Level:** low