### PR TITLE
fix: Fix container image tag in deployment manifest from invalid 'nginx:v999-nonexistent' to valid 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Using 'nginx:latest' provides a valid, publicly available image that can be pulled successfully. The deployment is managed by Argo CD with automated sync enabled, so the fix in Git will be automatically synced to the cluster.

**Risk Level:** low