### PR TITLE
fix: Update deployment manifest to use valid nginx image tag

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'v999-nonexistent' does not exist in the nginx Docker repository. Changing to 'nginx:latest' provides a valid, existing image that will allow the pod to start successfully. Argo CD will automatically sync this change to the cluster.

**Risk Level:** low