### PR TITLE
feat(models): refresh pinned AI model versions across providers

### DIFF
--- a/changelog.d/742.feature.md
+++ b/changelog.d/742.feature.md
@@ -7,8 +7,8 @@ Nine provider pins have been upgraded to each provider's current model. The prev
 - **OpenAI**: `gpt-5.4` → `gpt-5.6-terra`. Activated when `AI_PROVIDER=openai` or `AI_PROVIDER=custom`. Terra is the tier successor to the previous pin and is slightly cheaper ($2/$12 per million tokens versus $2.50/$15); `gpt-5.6-sol` is available as the flagship tier via `AI_MODEL` if you want to trade cost for capability.
 - **Google Gemini Flash**: `gemini-3-flash-preview` → `gemini-3.6-flash`. Activated when `AI_PROVIDER=google_flash`. This also moves the pin off a preview model onto a GA one — Google shipped only Flash-Lite variants at the 3.1 generation, so the full-Flash tier was unavailable at the last refresh.
 - **Moonshot Kimi**: `kimi-k2.5` → `kimi-k3`, with a 1M-token context window (up from 256K). Activated when `AI_PROVIDER=kimi`. This upgrade is time-critical: `kimi-k2.5` is already unavailable to newly registered Moonshot accounts and is sunset on 2026-08-31, so the old pin stops working regardless of upgrading.
-- **Alibaba Qwen**: `qwen3.6-plus` → `qwen3.7-plus`, with a 1M-token context window (up from 262K) and vision input. Activated when `AI_PROVIDER=alibaba`.
-- **xAI Grok**: `grok-4` → `grok-4.5`, with a 500K-token context window and native video input. Activated when `AI_PROVIDER=xai`.
+- **Alibaba Qwen**: `qwen3.6-plus` → `qwen3.7-plus`, adding image understanding alongside text. Activated when `AI_PROVIDER=alibaba`.
+- **xAI Grok**: `grok-4` → `grok-4.5`, with a 500K-token context window and text and image input. Activated when `AI_PROVIDER=xai`.
 - **Amazon Bedrock**: `global.anthropic.claude-sonnet-4-6` → `global.anthropic.claude-sonnet-5`. Activated when `AI_PROVIDER=amazon_bedrock`.
 - **GitHub Copilot**: `claude-sonnet-4.6` → `claude-sonnet-5`. Activated when `AI_PROVIDER=copilot`.
 

--- a/changelog.d/742.feature.md
+++ b/changelog.d/742.feature.md
@@ -1,0 +1,17 @@
+## Refreshed Pinned AI Model Versions Across Nine Providers
+
+Nine provider pins have been upgraded to each provider's current model. The previous refresh was three months earlier, and every provider except Anthropic Haiku, Google Gemini Pro, and OpenRouter had shipped at least one newer model since.
+
+- **Anthropic Sonnet**: `claude-sonnet-4-6` → `claude-sonnet-5`. Activated by default and when `AI_PROVIDER=anthropic`.
+- **Anthropic Opus**: `claude-opus-4-7` → `claude-opus-5`. Activated when `AI_PROVIDER=anthropic_opus`.
+- **OpenAI**: `gpt-5.4` → `gpt-5.6-terra`. Activated when `AI_PROVIDER=openai` or `AI_PROVIDER=custom`. Terra is the tier successor to the previous pin and is slightly cheaper ($2/$12 per million tokens versus $2.50/$15); `gpt-5.6-sol` is available as the flagship tier via `AI_MODEL` if you want to trade cost for capability.
+- **Google Gemini Flash**: `gemini-3-flash-preview` → `gemini-3.6-flash`. Activated when `AI_PROVIDER=google_flash`. This also moves the pin off a preview model onto a GA one — Google shipped only Flash-Lite variants at the 3.1 generation, so the full-Flash tier was unavailable at the last refresh.
+- **Moonshot Kimi**: `kimi-k2.5` → `kimi-k3`, with a 1M-token context window (up from 256K). Activated when `AI_PROVIDER=kimi`. This upgrade is time-critical: `kimi-k2.5` is already unavailable to newly registered Moonshot accounts and is sunset on 2026-08-31, so the old pin stops working regardless of upgrading.
+- **Alibaba Qwen**: `qwen3.6-plus` → `qwen3.7-plus`, with a 1M-token context window (up from 262K) and vision input. Activated when `AI_PROVIDER=alibaba`.
+- **xAI Grok**: `grok-4` → `grok-4.5`, with a 500K-token context window and native video input. Activated when `AI_PROVIDER=xai`.
+- **Amazon Bedrock**: `global.anthropic.claude-sonnet-4-6` → `global.anthropic.claude-sonnet-5`. Activated when `AI_PROVIDER=amazon_bedrock`.
+- **GitHub Copilot**: `claude-sonnet-4.6` → `claude-sonnet-5`. Activated when `AI_PROVIDER=copilot`.
+
+Three pins were evaluated and deliberately left alone because they are already current: Anthropic Haiku (`claude-haiku-4-5-20251001` — no Haiku 5 generation exists), Google Gemini Pro (`gemini-3.1-pro-preview` — still the flagship Gemini and still preview-only), and OpenRouter (`anthropic/claude-haiku-4.5`). Both embedding models are also unchanged and current: OpenAI's `text-embedding-3-small` has no announced successor, and Google's `gemini-embedding-001` remains the GA option.
+
+No configuration changes are required for most users — the same provider API key environment variables continue to work, and `AI_MODEL` still overrides the pin for any provider. Two provider-side conditions are worth checking before upgrading: Amazon Bedrock users need Claude Sonnet 5 enabled for their AWS account, and GitHub Copilot's Claude Sonnet 5 requires a Copilot Pro, Pro+, Max, Business, or Enterprise plan. In either case, setting `AI_MODEL` to the previously pinned model restores the old behavior.

--- a/src/core/ai-provider.interface.ts
+++ b/src/core/ai-provider.interface.ts
@@ -226,7 +226,7 @@ export interface AIProvider {
    * NEW: Required to replace hardcoded model at claude.ts:181
    * Each provider has different model naming conventions.
    *
-   * @returns Model identifier (e.g., 'claude-sonnet-4-6', 'gpt-5.4', 'gemini-3.1-pro-preview')
+   * @returns Model identifier (e.g., 'claude-sonnet-5', 'gpt-5.6-terra', 'gemini-3.1-pro-preview')
    */
   getDefaultModel(): string;
 
@@ -242,7 +242,7 @@ export interface AIProvider {
   /**
    * Get the current model name being used
    *
-   * @returns Model name (e.g., 'grok-4', 'claude-sonnet-4-6')
+   * @returns Model name (e.g., 'grok-4.5', 'claude-sonnet-5')
    */
   getModelName(): string;
 

--- a/src/core/model-config.ts
+++ b/src/core/model-config.ts
@@ -13,8 +13,8 @@ export const CURRENT_MODELS = {
   google: 'gemini-3.1-pro-preview', // Still the flagship Gemini and still preview-only - no GA promotion, no 3.2+ Pro
   google_flash: 'gemini-3.6-flash', // Gemini 3.6 Flash - GA (no longer a preview pin); full-Flash tier restored after the 3.1 generation shipped Flash-Lite only
   kimi: 'kimi-k3', // Moonshot AI Kimi K3 - 1M context; replaces kimi-k2.5, which sunsets 2026-08-31
-  alibaba: 'qwen3.7-plus', // Alibaba Qwen 3.7-Plus - 1M context, multimodal (vision), GA since 2026-06-01
-  xai: 'grok-4.5', // Grok 4.5 - 500K context, native video input
+  alibaba: 'qwen3.7-plus', // Alibaba Qwen 3.7-Plus - text and image understanding (Model Studio)
+  xai: 'grok-4.5', // Grok 4.5 - 500K context, text and image input
   host: 'host', // Delegates generation to the client via MCP Sampling
   openrouter: 'anthropic/claude-haiku-4.5', // PRD #194: OpenRouter default model (overridden by AI_MODEL env var)
   custom: 'gpt-5.6-terra', // PRD #194: Custom endpoint default model (overridden by AI_MODEL env var)

--- a/src/core/model-config.ts
+++ b/src/core/model-config.ts
@@ -6,20 +6,20 @@
  */
 
 export const CURRENT_MODELS = {
-  anthropic: 'claude-sonnet-4-6',
-  anthropic_opus: 'claude-opus-4-7',
-  anthropic_haiku: 'claude-haiku-4-5-20251001',
-  openai: 'gpt-5.4',
-  google: 'gemini-3.1-pro-preview',
-  google_flash: 'gemini-3-flash-preview', // PRD #294: Gemini 3 Flash - faster/cheaper variant with same 1M context
-  kimi: 'kimi-k2.5', // PRD #353: Moonshot AI Kimi K2.5 - single model with thinking by default, 256K context
-  alibaba: 'qwen3.6-plus', // PRD #480: Alibaba Qwen 3.6-Plus - 262K context, 201 languages, MoE architecture
-  xai: 'grok-4',
+  anthropic: 'claude-sonnet-5',
+  anthropic_opus: 'claude-opus-5',
+  anthropic_haiku: 'claude-haiku-4-5-20251001', // Still the current Haiku - no 5-generation Haiku exists
+  openai: 'gpt-5.6-terra',
+  google: 'gemini-3.1-pro-preview', // Still the flagship Gemini and still preview-only - no GA promotion, no 3.2+ Pro
+  google_flash: 'gemini-3.6-flash', // Gemini 3.6 Flash - GA (no longer a preview pin); full-Flash tier restored after the 3.1 generation shipped Flash-Lite only
+  kimi: 'kimi-k3', // Moonshot AI Kimi K3 - 1M context; replaces kimi-k2.5, which sunsets 2026-08-31
+  alibaba: 'qwen3.7-plus', // Alibaba Qwen 3.7-Plus - 1M context, multimodal (vision), GA since 2026-06-01
+  xai: 'grok-4.5', // Grok 4.5 - 500K context, native video input
   host: 'host', // Delegates generation to the client via MCP Sampling
   openrouter: 'anthropic/claude-haiku-4.5', // PRD #194: OpenRouter default model (overridden by AI_MODEL env var)
-  custom: 'gpt-5.4', // PRD #194: Custom endpoint default model (overridden by AI_MODEL env var)
-  amazon_bedrock: 'global.anthropic.claude-sonnet-4-6', // PRD #175: Amazon Bedrock default model (overridden by AI_MODEL env var)
-  copilot: 'claude-sonnet-4.6', // PRD #587: GitHub Copilot provider - use dot notation (catalog ID); Copilot supports both /chat/completions and /v1/messages for Claude
+  custom: 'gpt-5.6-terra', // PRD #194: Custom endpoint default model (overridden by AI_MODEL env var)
+  amazon_bedrock: 'global.anthropic.claude-sonnet-5', // PRD #175: Amazon Bedrock default model (overridden by AI_MODEL env var)
+  copilot: 'claude-sonnet-5', // PRD #587: GitHub Copilot provider - catalog ID (dot notation only for minor versions, e.g. claude-sonnet-4.6); Copilot supports both /chat/completions and /v1/messages for Claude
 } as const;
 
 /**

--- a/src/core/tracing/ai-tracing.ts
+++ b/src/core/tracing/ai-tracing.ts
@@ -21,7 +21,7 @@ export interface AITracingOptions {
   /** AI provider name (e.g., 'anthropic', 'openai', 'google') */
   provider: string;
 
-  /** Model identifier (e.g., 'claude-sonnet-4-6', 'gpt-5.4', 'text-embedding-3-small') */
+  /** Model identifier (e.g., 'claude-sonnet-5', 'gpt-5.6-terra', 'text-embedding-3-small') */
   model: string;
 
   /** Operation type: 'chat', 'tool_loop', 'embeddings' */
@@ -70,14 +70,14 @@ export interface AITracingResult {
  *
  * @example Chat operation
  * const response = await withAITracing(
- *   { provider: 'anthropic', model: 'claude-sonnet-4-6', operation: 'chat' },
+ *   { provider: 'anthropic', model: 'claude-sonnet-5', operation: 'chat' },
  *   async () => await client.messages.create(...),
  *   (result) => ({ inputTokens: result.usage.input_tokens, outputTokens: result.usage.output_tokens })
  * );
  *
  * @example Tool loop operation
  * const result = await withAITracing(
- *   { provider: 'anthropic', model: 'claude-sonnet-4-6', operation: 'tool_loop' },
+ *   { provider: 'anthropic', model: 'claude-sonnet-5', operation: 'tool_loop' },
  *   async () => await provider.toolLoop(...),
  *   (result) => ({ inputTokens: result.totalTokens.input, outputTokens: result.totalTokens.output })
  * );
@@ -98,7 +98,7 @@ export async function withAITracing<T>(
   const tracer = trace.getTracer('dot-ai-mcp');
 
   // Span name format: "{operation} {model}"
-  // Examples: "chat claude-sonnet-4-6", "tool_loop claude-sonnet-4-6", "embeddings text-embedding-3-small"
+  // Examples: "chat claude-sonnet-5", "tool_loop claude-sonnet-5", "embeddings text-embedding-3-small"
   const spanName = `${options.operation} ${options.model}`;
 
   return await tracer.startActiveSpan(


### PR DESCRIPTION
## What this does

Bumps nine provider pins in `src/core/model-config.ts` to each provider's current model. The last refresh was PRD #480 (merged 2026-05-08); three months of provider releases have accumulated since.

No PRD for this one — the change is mechanically confined to one file plus the JSDoc/comment examples that #480 established as kept-in-sync with the pins.

| Key | Before | After |
|---|---|---|
| `anthropic` | `claude-sonnet-4-6` | `claude-sonnet-5` |
| `anthropic_opus` | `claude-opus-4-7` | `claude-opus-5` |
| `openai` | `gpt-5.4` | `gpt-5.6-terra` |
| `custom` | `gpt-5.4` | `gpt-5.6-terra` |
| `google_flash` | `gemini-3-flash-preview` | `gemini-3.6-flash` |
| `kimi` | `kimi-k2.5` | `kimi-k3` |
| `alibaba` | `qwen3.6-plus` | `qwen3.7-plus` |
| `xai` | `grok-4` | `grok-4.5` |
| `amazon_bedrock` | `global.anthropic.claude-sonnet-4-6` | `global.anthropic.claude-sonnet-5` |
| `copilot` | `claude-sonnet-4.6` | `claude-sonnet-5` |

**Verified still current, deliberately unchanged:** `anthropic_haiku` (no Haiku 5 generation exists), `google` (Gemini 3.1 Pro is still the flagship and still preview-only — no GA promotion, no 3.2+ Pro), `openrouter` (tracks Haiku 4.5), and both embedding models (`text-embedding-3-small` has no announced successor; `gemini-embedding-001` is GA while `gemini-embedding-2` is preview).

## Why now — `kimi` has a deadline

`kimi-k2.5` is **already unavailable to newly registered accounts**, and Moonshot sunsets it on **2026-08-31**. That pin fails on its own regardless of this PR.

## This retires every "hold" from PRD #480

Each hold was recorded with a rationale that has since been invalidated by events:

| Decision | Held because | Status now |
|---|---|---|
| D1 Grok | 4.3 was beta, Grok 5 timeline unconfirmed | Grok 4.5 shipped GA 2026-07-08 |
| D3 Gemini Flash | Google shipped no full Flash at 3.1, only Flash-Lite | 3.5 and 3.6 Flash are both GA |
| D5 GPT | GPT-5.5 failed the Helm-fallback recommend test | 5.6 is a different model line (Sol/Terra/Luna), needs its own validation |
| D6 Kimi | K2.6 regressed 4 tests on agentic-loop convergence | K3's 1M context addresses the context overflow behind that regression |

None of #480's promised follow-up PRDs or issues were ever filed, which is why this drift went unnoticed for three months.

## Decisions taken here

**GPT tier → Terra.** `gpt-5.6` ships in three tiers. `gpt-5.4` was \$2.50/\$15; Terra is \$2/\$12 (the like-for-like successor, slightly cheaper), Sol is the flagship at \$5/\$30, Luna is \$0.20/\$1.20. Terra keeps the current capability tier without a cost increase. Change one line if you'd rather trade cost for capability.

**Not classified as `breaking`.** The config surface (`AI_MODEL`, provider API keys) is unchanged and nothing users wrote stops working, so this is a `feature` fragment — matching the #480 precedent. At v2.0.0 a `breaking` fragment would force v3.0.0, which a default-model refresh does not warrant. Two caveats belong in the release notes rather than the version number, and are in the fragment: Bedrock users must have Sonnet 5 enabled for their account, and Copilot's Sonnet 5 requires a Pro/Pro+/Max/Business/Enterprise plan. Both are recoverable by setting `AI_MODEL`.

## Model ID verification

Every pin was verified. Five were exercised with a **real API call** through the project's own `AIProviderFactory` (asserting `getModelName()` matches the pin *and* that the model returns a completion); the rest were confirmed against the vendor's own published identifier.

| Pin | Evidence | Certain? |
|---|---|---|
| `claude-sonnet-5` | live API call — responded | ✅ |
| `claude-opus-5` | live API call — responded | ✅ |
| `gemini-3.6-flash` | live API call — responded | ✅ |
| `kimi-k3` | live API call — responded | ✅ |
| `grok-4.5` | live API call — responded | ✅ |
| `gpt-5.6-terra` | exact ID on OpenAI's official models page | ✅ |
| `global.anthropic.claude-sonnet-5` | exact string in the AWS Bedrock model card, "Global inference ID" column | ✅ |
| `qwen3.7-plus` | exact ID on Alibaba Model Studio's official model list | ✅ |
| `claude-sonnet-5` (Copilot) | GitHub publishes display names, not API IDs; matches catalog convention and third-party Copilot clients | ⚠️ likely, unverified |

This retires the PRD #480 D3 failure mode (an assumed-but-never-published model ID that 404'd across every test) for eight of the nine. **Copilot is the one residual risk** — it can't be tested here because the available `GITHUB_TOKEN` is a `ghp_` classic PAT, which `api.githubcopilot.com` rejects outright.

## Test status

- **Build + lint:** pass.
- **Unit tests:** 924/925 pass. The one failure (`vercel-provider.copilot.test.ts > e2e: resolver returns a usable token from env`) needs a `GITHUB_COPILOT_TOKEN` and **fails identically on unmodified `main`** — pre-existing.
- **Integration tests: all 8 CI groups pass** on this PR — `version`, `recommend`, `remediate`, `query`, `base-group-1` (includes `operate`), `base-group-2`, `manage-org-data-policies-capabilities`, and `unified-knowledge-base`.

CI exercises the **`anthropic` pin only** (`ci.yml`'s matrix supplies only `ANTHROPIC_API_KEY` and never sets `AI_PROVIDER`), so `claude-sonnet-5` — the default every user gets — is validated end to end, including the `recommend` flow that caught GPT-5.5 in #480 and the `operate` flow that caught Kimi K2.6.

**Residual risk is behavioral drift on the other eight pins.** A valid model ID can still change how tool flows behave; that is how both of #480's regressions were found. Ranked by exposure:

1. `kimi-k2.5` → `kimi-k3` — largest generation jump here, and Kimi is exactly where #480's agentic-loop regression appeared.
2. `gpt-5.6-terra` — a different model line from the `gpt-5.5` that failed #480's Helm-fallback test; never behaviorally exercised.
3. `grok-4.5`, `qwen3.7-plus`, `gemini-3.6-flash`, `claude-opus-5` — all name-verified, none behaviorally exercised.
4. `copilot` — plus the unverified ID above.

To cover any of them: `USE_LOCAL_EMBEDDINGS=true AI_PROVIDER=<provider> npm run test:integration <group>`, one provider at a time (the runner rebuilds the cluster each run). `operate` for `kimi` is the single highest-value run. Keys for `openai`, `alibaba`, `amazon_bedrock`, and `copilot` are not available locally — those need the commented-out entries in `.env.vals.yaml`, or a provider input added to `ci.yml`.

## Out of scope

`src/evaluation/model-metadata.json` is still on its 2025-10-15 comparison set and no longer matches any production pin. It's refreshed via the `/update-model-metadata` command (PRD #480 Milestone 8, deferred) and doesn't gate these pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refreshed default AI model selections across supported providers, including updated context windows, capabilities, pricing, and availability details.
  - Added updated guidance for provider activation, account requirements, and fallback behavior.
- **Documentation**
  - Updated model examples and configuration references to reflect current recommended models.
  - Clarified unchanged models, including selected embedding and provider options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->