### PR TITLE
fix: Fix invalid image tag in deployment manifest in Git source repository

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' (a valid, existing tag) allows the container to be successfully pulled. Argo CD will automatically detect the change in Git and resync the deployment, causing new pods to be created with the corrected image.

**Risk Level:** low