### PR TITLE
fix: Update image tag in deployment.yaml from nginx:v999-nonexistent to nginx:1.25

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:1.25
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Using a valid and stable nginx image tag resolves the ImagePullBackOff error. The Argo CD automated sync policy (enabled with selfHeal:true) will automatically detect and apply this change, rolling out updated pods.

**Risk Level:** low