### PR TITLE
fix(helm): configure local embeddings model

### DIFF
--- a/changelog.d/753-local-embeddings-model.bugfix.md
+++ b/changelog.d/753-local-embeddings-model.bugfix.md
@@ -1,4 +1,5 @@
 **Local embeddings use the configured TEI model**
 
-Helm deployments with local embeddings enabled now pass `localEmbeddings.model`
-to the MCP server, preventing model-mismatch warnings on embedding requests.
+Helm deployments with local embeddings enabled now pass the model name served by
+TEI to the MCP server, including the prefetched model path, preventing
+model-mismatch warnings on embedding requests.

--- a/changelog.d/753-local-embeddings-model.bugfix.md
+++ b/changelog.d/753-local-embeddings-model.bugfix.md
@@ -1,0 +1,4 @@
+**Local embeddings use the configured TEI model**
+
+Helm deployments with local embeddings enabled now pass `localEmbeddings.model`
+to the MCP server, preventing model-mismatch warnings on embedding requests.

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -110,7 +110,11 @@ spec:
         - name: CUSTOM_EMBEDDINGS_BASE_URL
           value: "http://{{ .Release.Name }}-local-embeddings.{{ .Release.Namespace }}.svc.cluster.local:80/v1"
         - name: EMBEDDINGS_MODEL
+{{- if .Values.localEmbeddings.prefetch.enabled }}
+          value: "/models/model"
+{{- else }}
           value: {{ .Values.localEmbeddings.model | quote }}
+{{- end }}
         - name: EMBEDDINGS_DIMENSIONS
           value: {{ .Values.localEmbeddings.dimensions | quote }}
 {{- end }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -109,6 +109,8 @@ spec:
           value: "local-embeddings-no-key-required"
         - name: CUSTOM_EMBEDDINGS_BASE_URL
           value: "http://{{ .Release.Name }}-local-embeddings.{{ .Release.Namespace }}.svc.cluster.local:80/v1"
+        - name: EMBEDDINGS_MODEL
+          value: {{ .Values.localEmbeddings.model | quote }}
         - name: EMBEDDINGS_DIMENSIONS
           value: {{ .Values.localEmbeddings.dimensions | quote }}
 {{- end }}

--- a/tests/integration/tools/version.test.ts
+++ b/tests/integration/tools/version.test.ts
@@ -26,7 +26,12 @@ describe.concurrent('Version Tool Integration', () => {
   // Embedding config depends on whether local embeddings are used (CI) or OpenAI (local dev)
   const useLocalEmbeddings = process.env.USE_LOCAL_EMBEDDINGS === 'true';
   const expectedEmbedding = useLocalEmbeddings
-    ? { available: true, provider: 'custom', model: 'custom', dimensions: 384 }
+    ? {
+        available: true,
+        provider: 'custom',
+        model: '/models/model',
+        dimensions: 384,
+      }
     : {
         available: true,
         provider: 'openai',
@@ -51,11 +56,11 @@ describe.concurrent('Version Tool Integration', () => {
             apiGroup: '',
             labels: {},
             createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
-          }
+            updatedAt: new Date().toISOString(),
+          },
         ],
         deletes: [],
-        isResync: false
+        isResync: false,
       });
     }, 30000);
 

--- a/tests/unit/helm/embeddings-env.test.ts
+++ b/tests/unit/helm/embeddings-env.test.ts
@@ -127,7 +127,11 @@ describe.concurrent('Embeddings env var rendering (Issue #465)', () => {
     expect(apiKeyEntries).toHaveLength(1);
     expect(apiKeyEntries[0].value).toBe('local-embeddings-no-key-required');
 
-    // EMBEDDINGS_DIMENSIONS from localEmbeddings
+    // EMBEDDINGS_MODEL and EMBEDDINGS_DIMENSIONS from localEmbeddings
+    const modelEntries = env.filter(e => e.name === 'EMBEDDINGS_MODEL');
+    expect(modelEntries).toHaveLength(1);
+    expect(modelEntries[0].value).toBe('sentence-transformers/all-MiniLM-L6-v2');
+
     const dimEntries = env.filter(e => e.name === 'EMBEDDINGS_DIMENSIONS');
     expect(dimEntries).toHaveLength(1);
     expect(dimEntries[0].value).toBe('384');
@@ -138,9 +142,11 @@ describe.concurrent('Embeddings env var rendering (Issue #465)', () => {
       'ai.customEndpoint.enabled=true',
       'ai.customEndpoint.baseURL=https://my-llm:443/v1',
       'ai.customEndpoint.embeddingsBaseURL=https://my-embeddings:443/v1',
+      'ai.customEndpoint.embeddingsModel=custom-embed',
       'ai.customEndpoint.embeddingsDimensions=768',
       'ai.customEndpoint.headers={"X-Custom":"val"}',
       'localEmbeddings.enabled=true',
+      'localEmbeddings.model=local-embed',
     ]);
     const env = getMcpServerEnv(docs);
 
@@ -154,7 +160,11 @@ describe.concurrent('Embeddings env var rendering (Issue #465)', () => {
     expect(apiKeyEntries).toHaveLength(1);
     expect(apiKeyEntries[0].value).toBe('local-embeddings-no-key-required');
 
-    // EMBEDDINGS_DIMENSIONS from localEmbeddings (not customEndpoint)
+    // EMBEDDINGS_MODEL and EMBEDDINGS_DIMENSIONS from localEmbeddings (not customEndpoint)
+    const modelEntries = env.filter(e => e.name === 'EMBEDDINGS_MODEL');
+    expect(modelEntries).toHaveLength(1);
+    expect(modelEntries[0].value).toBe('local-embed');
+
     const dimEntries = env.filter(e => e.name === 'EMBEDDINGS_DIMENSIONS');
     expect(dimEntries).toHaveLength(1);
     expect(dimEntries[0].value).toBe('384');

--- a/tests/unit/helm/embeddings-env.test.ts
+++ b/tests/unit/helm/embeddings-env.test.ts
@@ -39,44 +39,63 @@ function helmTemplate(setValues: string[] = []): unknown[] {
   return yaml.loadAll(output).filter(Boolean);
 }
 
-function findResourcesByKind<T>(docs: unknown[], kind: string, nameIncludes?: string): T[] {
+function findResourcesByKind<T>(
+  docs: unknown[],
+  kind: string,
+  nameIncludes?: string
+): T[] {
   return docs.filter(
     (doc: unknown) =>
       typeof doc === 'object' &&
       doc !== null &&
       (doc as Record<string, unknown>).kind === kind &&
       (!nameIncludes ||
-        ((doc as Record<string, unknown>).metadata as Record<string, unknown>)?.name
+        (
+          (doc as Record<string, unknown>).metadata as Record<string, unknown>
+        )?.name
           ?.toString()
           .includes(nameIncludes))
   ) as T[];
 }
 
 function getMcpServerEnv(docs: unknown[]) {
-  const deployments = findResourcesByKind<DeploymentResource>(docs, 'Deployment');
+  const deployments = findResourcesByKind<DeploymentResource>(
+    docs,
+    'Deployment'
+  );
   const mainDeploy = deployments.find(
-    d => !d.metadata.name.includes('plugin') && !d.metadata.name.includes('dex') && !d.metadata.name.includes('local-embeddings')
+    d =>
+      !d.metadata.name.includes('plugin') &&
+      !d.metadata.name.includes('dex') &&
+      !d.metadata.name.includes('local-embeddings')
   );
   expect(mainDeploy).toBeDefined();
-  const container = mainDeploy!.spec.template.spec.containers.find(c => c.name === 'mcp-server');
+  const container = mainDeploy!.spec.template.spec.containers.find(
+    c => c.name === 'mcp-server'
+  );
   expect(container).toBeDefined();
   return container!.env || [];
 }
 
 describe.concurrent('Embeddings env var rendering (Issue #465)', () => {
-
   test('neither enabled: CUSTOM_EMBEDDINGS_API_KEY from secretKeyRef, no CUSTOM_EMBEDDINGS_BASE_URL', () => {
     const docs = helmTemplate();
     const env = getMcpServerEnv(docs);
 
-    const baseUrlEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL');
+    const baseUrlEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL'
+    );
     expect(baseUrlEntries).toHaveLength(0);
 
-    const apiKeyEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY');
+    const apiKeyEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY'
+    );
     expect(apiKeyEntries).toHaveLength(1);
     expect(apiKeyEntries[0].valueFrom?.secretKeyRef).toBeDefined();
 
-    const dimensionsEntries = env.filter(e => e.name === 'EMBEDDINGS_DIMENSIONS');
+    const dimensionsEntries = env.filter(
+      e => e.name === 'EMBEDDINGS_DIMENSIONS'
+    );
     expect(dimensionsEntries).toHaveLength(0);
   });
 
@@ -91,12 +110,16 @@ describe.concurrent('Embeddings env var rendering (Issue #465)', () => {
     const env = getMcpServerEnv(docs);
 
     // CUSTOM_EMBEDDINGS_BASE_URL from customEndpoint
-    const baseUrlEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL');
+    const baseUrlEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL'
+    );
     expect(baseUrlEntries).toHaveLength(1);
     expect(baseUrlEntries[0].value).toBe('https://my-embeddings:443/v1');
 
     // CUSTOM_EMBEDDINGS_API_KEY from secretKeyRef
-    const apiKeyEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY');
+    const apiKeyEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY'
+    );
     expect(apiKeyEntries).toHaveLength(1);
     expect(apiKeyEntries[0].valueFrom?.secretKeyRef).toBeDefined();
 
@@ -111,30 +134,46 @@ describe.concurrent('Embeddings env var rendering (Issue #465)', () => {
   });
 
   test('only localEmbeddings: embeddings vars from local service, dummy API key', () => {
-    const docs = helmTemplate([
-      'localEmbeddings.enabled=true',
-    ]);
+    const docs = helmTemplate(['localEmbeddings.enabled=true']);
     const env = getMcpServerEnv(docs);
 
     // CUSTOM_EMBEDDINGS_BASE_URL points to local service
-    const baseUrlEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL');
+    const baseUrlEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL'
+    );
     expect(baseUrlEntries).toHaveLength(1);
     expect(baseUrlEntries[0].value).toContain('local-embeddings');
     expect(baseUrlEntries[0].value).toContain('/v1');
 
     // CUSTOM_EMBEDDINGS_API_KEY is the dummy value (no secretKeyRef duplicate)
-    const apiKeyEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY');
+    const apiKeyEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY'
+    );
     expect(apiKeyEntries).toHaveLength(1);
     expect(apiKeyEntries[0].value).toBe('local-embeddings-no-key-required');
 
     // EMBEDDINGS_MODEL and EMBEDDINGS_DIMENSIONS from localEmbeddings
     const modelEntries = env.filter(e => e.name === 'EMBEDDINGS_MODEL');
     expect(modelEntries).toHaveLength(1);
-    expect(modelEntries[0].value).toBe('sentence-transformers/all-MiniLM-L6-v2');
+    expect(modelEntries[0].value).toBe(
+      'sentence-transformers/all-MiniLM-L6-v2'
+    );
 
     const dimEntries = env.filter(e => e.name === 'EMBEDDINGS_DIMENSIONS');
     expect(dimEntries).toHaveLength(1);
     expect(dimEntries[0].value).toBe('384');
+  });
+
+  test('localEmbeddings with prefetch uses the model path served by TEI', () => {
+    const docs = helmTemplate([
+      'localEmbeddings.enabled=true',
+      'localEmbeddings.prefetch.enabled=true',
+    ]);
+    const env = getMcpServerEnv(docs);
+
+    const modelEntries = env.filter(e => e.name === 'EMBEDDINGS_MODEL');
+    expect(modelEntries).toHaveLength(1);
+    expect(modelEntries[0].value).toBe('/models/model');
   });
 
   test('both enabled: localEmbeddings wins for embeddings, customEndpoint still sets LLM vars', () => {
@@ -151,12 +190,16 @@ describe.concurrent('Embeddings env var rendering (Issue #465)', () => {
     const env = getMcpServerEnv(docs);
 
     // CUSTOM_EMBEDDINGS_BASE_URL from localEmbeddings (not customEndpoint)
-    const baseUrlEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL');
+    const baseUrlEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_BASE_URL'
+    );
     expect(baseUrlEntries).toHaveLength(1);
     expect(baseUrlEntries[0].value).toContain('local-embeddings');
 
     // CUSTOM_EMBEDDINGS_API_KEY is the dummy value (exactly one entry)
-    const apiKeyEntries = env.filter(e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY');
+    const apiKeyEntries = env.filter(
+      e => e.name === 'CUSTOM_EMBEDDINGS_API_KEY'
+    );
     expect(apiKeyEntries).toHaveLength(1);
     expect(apiKeyEntries[0].value).toBe('local-embeddings-no-key-required');
 


### PR DESCRIPTION
## What

Configure `EMBEDDINGS_MODEL` in the MCP server deployment whenever local embeddings are enabled, using the existing `localEmbeddings.model` Helm value.

## Why

The local TEI deployment already uses this model, but the MCP server currently falls back to `text-embedding-3-small`. Requests still succeed, but TEI emits a model-mismatch warning for every embedding request.

## How

- render `EMBEDDINGS_MODEL` alongside the local embeddings URL and dimensions
- verify the default local model is rendered
- verify local embeddings override a simultaneously configured custom embeddings model without duplicate env entries
- add the required bugfix changelog fragment

## Testing

- `npx vitest --config=vitest.unit.config.ts tests/unit/helm/embeddings-env.test.ts` (5 passed)
- `npm run lint`
- `npm run build` (under Git Bash on Windows)
- Full unit run: 923 passed, 3 skipped, 14 unrelated existing Helm tests failed due command quoting/empty-value behavior in this Windows environment
- Integration tests were not run because Docker/Kind are unavailable locally; CI can exercise the repository integration workflow

Fixes #753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Helm deployments now pass the configured local embeddings model to the MCP server.
  - Prevented embedding-request model mismatch warnings when local embeddings are enabled.
  - Ensured the configured local model takes precedence over the custom endpoint model.
  - Correctly use the prefetched model path when local model prefetching is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->