### PR TITLE
feat(helm): support local embeddings scheduling

### DIFF
--- a/changelog.d/755-local-embeddings-scheduling.feature.md
+++ b/changelog.d/755-local-embeddings-scheduling.feature.md
@@ -1,0 +1,7 @@
+**Pod scheduling options for the local embeddings Deployment**
+
+`localEmbeddings` now supports `nodeSelector`, `affinity`, and `tolerations`
+so the in-cluster TEI embedding service can be pinned to specific nodes,
+constrained by affinity rules, or scheduled onto tainted nodes. All three
+default to empty and are omitted from the rendered manifest when unset, so
+existing deployments are unaffected.

--- a/charts/templates/local-embeddings.yaml
+++ b/charts/templates/local-embeddings.yaml
@@ -34,6 +34,18 @@ spec:
         {{- $podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.localEmbeddings.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.localEmbeddings.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.localEmbeddings.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.localEmbeddings.prefetch.enabled }}
       # TEI's built-in downloader cannot fetch models from HuggingFace's Xet storage
       # backend (it fails with "Header content-range is missing"). Prefetch the model

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -362,6 +362,11 @@ localEmbeddings:
     tag: "cpu-latest"
   model: "sentence-transformers/all-MiniLM-L6-v2"  # Embedding model (384 dimensions)
   dimensions: 384                   # Must match the model's output dimensions
+  # Pod scheduling (optional). Pin the local embeddings workload to specific
+  # nodes, or constrain placement with affinity and tolerations.
+  nodeSelector: {}                  # Map of node labels to match
+  affinity: {}                      # Pod affinity/anti-affinity rules
+  tolerations: []                   # Pod tolerations for tainted nodes
   # Opt-in workaround (default off). TEI's built-in downloader cannot fetch models
   # stored on HuggingFace's Xet backend (fails with "Header content-range is
   # missing"). When enabled, an initContainer prefetches the model with a Xet-aware

--- a/docs/ai-engine/setup/deployment.md
+++ b/docs/ai-engine/setup/deployment.md
@@ -403,7 +403,7 @@ This is already included in the [Quick Start](#quick-start-5-minutes) above. No 
 | **Model** | `all-MiniLM-L6-v2` (384 dimensions) |
 | **Resource footprint** | ~256 MB RAM, 250m CPU (request) |
 | **GPU** | Not required |
-| **Architecture** | amd64 only (no ARM64/Apple Silicon — see [TEI issue #769](https://github.com/huggingface/text-embeddings-inference/issues/769)) |
+| **Architecture** | amd64 only (no ARM64/Apple Silicon — see [TEI issue #769](https://github.com/huggingface/text-embeddings-inference/issues/769)). On mixed-arch clusters, pin the pod with [nodeSelector](#local-embeddings-scheduling). |
 
 To customize the model or resources:
 
@@ -420,6 +420,37 @@ localEmbeddings:
       cpu: "1"
       memory: "512Mi"
 ```
+
+#### Pod scheduling {#local-embeddings-scheduling}
+
+The TEI image is amd64-only, so on a mixed-architecture cluster the local
+embeddings pod must be pinned to compatible nodes. Use `nodeSelector`,
+`affinity`, and `tolerations` to control placement — for example, to keep it on
+amd64 nodes, target a dedicated node pool, and tolerate that pool's taint:
+
+```yaml
+localEmbeddings:
+  enabled: true
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: ml
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values: ["m7i.large"]
+```
+
+All three default to empty and are omitted from the rendered Deployment when
+unset, so existing installations are unaffected. They apply only to the local
+embeddings Deployment — no other workload in the chart is affected.
 
 #### Embedding model prefetch (HuggingFace Xet workaround) {#local-embeddings-prefetch}
 

--- a/tests/unit/helm/local-embeddings-scheduling.test.ts
+++ b/tests/unit/helm/local-embeddings-scheduling.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit Test: localEmbeddings pod scheduling values
+ *
+ * Tests that nodeSelector, affinity, and tolerations under
+ * localEmbeddings render only on the local-embeddings Deployment
+ * and only when explicitly configured (empty defaults stay empty).
+ */
+
+import { describe, test, expect } from 'vitest';
+import { execSync } from 'child_process';
+import * as yaml from 'js-yaml';
+
+interface DeploymentResource {
+  apiVersion: string;
+  kind: 'Deployment';
+  metadata: { name: string };
+  spec: {
+    template: {
+      spec: {
+        nodeSelector?: Record<string, string>;
+        affinity?: Record<string, unknown>;
+        tolerations?: Array<Record<string, unknown>>;
+        containers: Array<{ name: string }>;
+      };
+    };
+  };
+}
+
+const NODE_SELECTOR_JSON = '{"kubernetes.io/arch":"arm64"}';
+const AFFINITY_JSON =
+  '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/arch","operator":"In","values":["arm64"]}]}]}}}';
+const TOLERATIONS_JSON =
+  '[{"key":"kubernetes.io/arch","operator":"Equal","value":"arm64","effect":"NoSchedule"}]';
+
+function helmTemplate(setArgs: string[] = []): unknown[] {
+  const chartPath = './charts';
+  const args = setArgs.join(' ');
+  const cmd = `helm template test-release ${chartPath} ${args} 2>&1`;
+  const output = execSync(cmd, { encoding: 'utf-8' });
+  return yaml.loadAll(output).filter(Boolean);
+}
+
+function findDeployments(
+  docs: unknown[],
+  nameIncludes?: string
+): DeploymentResource[] {
+  return docs.filter(
+    (doc: unknown) =>
+      typeof doc === 'object' &&
+      doc !== null &&
+      (doc as Record<string, unknown>).kind === 'Deployment' &&
+      (!nameIncludes ||
+        ((doc as Record<string, unknown>).metadata as Record<string, unknown>)
+          ?.name
+          ?.toString()
+          .includes(nameIncludes))
+  ) as DeploymentResource[];
+}
+
+function customSchedulingArgs(): string[] {
+  return [
+    '--set localEmbeddings.enabled=true',
+    `--set-json 'localEmbeddings.nodeSelector=${NODE_SELECTOR_JSON}'`,
+    `--set-json 'localEmbeddings.affinity=${AFFINITY_JSON}'`,
+    `--set-json 'localEmbeddings.tolerations=${TOLERATIONS_JSON}'`,
+  ];
+}
+
+describe.concurrent('localEmbeddings pod scheduling values', () => {
+  test('enabled with empty defaults: nodeSelector, affinity, tolerations absent from pod spec', () => {
+    const docs = helmTemplate(['--set localEmbeddings.enabled=true']);
+    const leDeploy = findDeployments(docs, 'local-embeddings')[0];
+    expect(leDeploy).toBeDefined();
+
+    const podSpec = leDeploy!.spec.template.spec;
+    expect(podSpec.nodeSelector).toBeUndefined();
+    expect(podSpec.affinity).toBeUndefined();
+    expect(podSpec.tolerations).toBeUndefined();
+  });
+
+  test('custom values render on Deployment/test-release-local-embeddings', () => {
+    const docs = helmTemplate(customSchedulingArgs());
+    const leDeploy = findDeployments(docs, 'local-embeddings')[0];
+    expect(leDeploy).toBeDefined();
+    expect(leDeploy!.metadata.name).toBe('test-release-local-embeddings');
+
+    const podSpec = leDeploy!.spec.template.spec;
+    expect(podSpec.nodeSelector).toEqual({
+      'kubernetes.io/arch': 'arm64',
+    });
+
+    expect(podSpec.affinity).toEqual({
+      nodeAffinity: {
+        requiredDuringSchedulingIgnoredDuringExecution: {
+          nodeSelectorTerms: [
+            {
+              matchExpressions: [
+                {
+                  key: 'kubernetes.io/arch',
+                  operator: 'In',
+                  values: ['arm64'],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(podSpec.tolerations).toEqual([
+      {
+        key: 'kubernetes.io/arch',
+        operator: 'Equal',
+        value: 'arm64',
+        effect: 'NoSchedule',
+      },
+    ]);
+  });
+
+  test('scheduling values affect only the local-embeddings Deployment', () => {
+    const docs = helmTemplate(customSchedulingArgs());
+    const deployments = findDeployments(docs);
+    expect(deployments.length).toBeGreaterThan(1);
+
+    const leDeploy = deployments.find(d =>
+      d.metadata.name.includes('local-embeddings')
+    );
+    expect(leDeploy).toBeDefined();
+    expect(leDeploy!.spec.template.spec.nodeSelector).toBeDefined();
+    expect(leDeploy!.spec.template.spec.affinity).toBeDefined();
+    expect(leDeploy!.spec.template.spec.tolerations).toBeDefined();
+
+    const otherDeploys = deployments.filter(
+      d => !d.metadata.name.includes('local-embeddings')
+    );
+    expect(otherDeploys.length).toBeGreaterThan(0);
+
+    for (const deploy of otherDeploys) {
+      const podSpec = deploy.spec.template.spec;
+      expect(podSpec.nodeSelector).toBeUndefined();
+      expect(podSpec.affinity).toBeUndefined();
+      expect(podSpec.tolerations).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Description

**What does this PR do?**

Adds optional pod scheduling values for the local embeddings Deployment:

* `localEmbeddings.nodeSelector`
* `localEmbeddings.affinity`
* `localEmbeddings.tolerations`

The values render only on the local embeddings Deployment. Empty defaults omit the fields, preserving existing behavior. This PR also adds a changelog fragment and focused Helm rendering tests.

**Why is this change needed?**

TEI may use architecture-specific images. Chart consumers currently need an out-of-chart post-render patch to schedule local embeddings on compatible nodes. Native Helm values remove that workaround and also support affinity and taint-based scheduling.

## Related Issues

* Closes #755

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
* [x] 📚 Documentation update
* [ ] ♻️ Refactoring (no functional changes)
* [x] ✅ Test updates (adding or updating tests)
* [x] 🔧 Configuration changes
* [ ] 🚀 Performance improvements
* [ ] 🎨 Style changes (formatting, naming, etc.)
* [ ] 📦 Dependency updates
* [ ] 🔨 CI/CD changes

## Conventional Commit Format

PR title:

```text
feat(helm): support local embeddings scheduling
```

## Testing Checklist

* [x] Tests added or updated
* [ ] All existing tests pass locally
* [x] Manual testing performed
* [x] Test coverage maintained or improved

**Test commands run:**

```bash
git diff --check
helm lint ./charts
helm template test-release ./charts
helm template test-release ./charts --set localEmbeddings.enabled=true
npm run test:unit -- tests/unit/helm/local-embeddings-scheduling.test.ts
npm run test:unit
npm run lint
```

**Test results:**

* `git diff --check`: passed
* Helm lint: 1 chart linted, 0 failed
* Focused scheduling tests: 1 test file, 3 tests passed
* Unit test suite: 940 tests passed, 3 skipped
* Lint: passed
* Empty defaults render no scheduling fields
* Configured values render correctly
* Only the local embeddings Deployment is affected

The integration test suite was not run locally because it requires AI API credentials, Docker/operator setup, and a fresh Kind cluster.

## Documentation Checklist

* [ ] README.md updated (if user-facing changes)
* [x] Documentation updated (changelog fragment added)
* [ ] Code comments added for complex logic
* [ ] API documentation updated (if API changes)

## Security Checklist

* [x] No secrets or credentials committed
* [ ] Input validation implemented where needed
* [x] Security implications considered and documented
* [ ] Dependencies scanned for vulnerabilities
* [ ] Authentication/authorization logic reviewed
* [ ] Error messages don't leak sensitive information

This change adds optional Helm scheduling configuration only. It does not modify dependencies, authentication, authorization, secret handling, or error messages.

## Breaking Changes

**Does this PR introduce breaking changes?**

* [ ] Yes
* [x] No

**If yes, describe the breaking changes and migration path:**

Not applicable. Empty defaults preserve the current rendered behavior.

## Checklist

* [x] My code follows the project's code style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings or errors
* [x] I have added tests that prove my feature works
* [ ] New and existing tests pass locally with my changes
* [ ] Any dependent changes have been merged and published
* [x] PR title follows Conventional Commits format

The integration suite was not run locally, as explained above. This PR has no dependent changes.

## Additional Context

**Reviewer Notes:**

Please review the Helm indentation under `spec.template.spec` and confirm that the scheduling fields are intentionally scoped only to the local embeddings Deployment.

**Follow-up Work:**

After this feature is released, downstream GitOps consumers can replace Sveltos post-render patches with native `localEmbeddings.nodeSelector` values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `nodeSelector`, affinity, and toleration settings for local embeddings deployments.
  * Scheduling settings are applied only when configured, with empty defaults preserved.
  * These options affect only the local embeddings deployment and support mixed-architecture cluster scheduling.
* **Documentation**
  * Documented the new scheduling options, default behavior, and configuration examples for local embeddings deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->