### PR TITLE
feat(helm): support nodeSelector, affinity and tolerations for local embeddings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,17 +4,6 @@
     "dot-ai"
   ],
   "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "command": "dot-ai skills generate --agent claude-code",
-            "type": "command"
-          }
-        ],
-        "matcher": "startup"
-      }
-    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/changelog.d/755.feature.md
+++ b/changelog.d/755.feature.md
@@ -1,0 +1,7 @@
+## Pod Scheduling for Local Embeddings
+
+The local embeddings Deployment now accepts standard Kubernetes pod scheduling controls, so platform operators can control which nodes it runs on without an out-of-chart post-render patch.
+
+Three optional Helm values — `localEmbeddings.nodeSelector`, `localEmbeddings.affinity`, and `localEmbeddings.tolerations` — are rendered verbatim under `spec.template.spec` of the local-embeddings Deployment only. Use them to pin the TEI pod to amd64 nodes on a mixed-architecture cluster (the default TEI image is amd64-only), place it on a dedicated or accelerator node pool, or let it run on tainted nodes. All three are empty by default and are omitted entirely from the rendered manifest, so existing installs are unchanged unless configured. No architecture or scheduling policy is hardcoded.
+
+See [Pod scheduling](https://devopstoolkit.ai/docs/mcp/ai-engine/setup/deployment#local-embeddings-scheduling) for configuration examples.

--- a/charts/templates/local-embeddings.yaml
+++ b/charts/templates/local-embeddings.yaml
@@ -112,6 +112,18 @@ spec:
       - name: model-cache
         emptyDir: {}
       {{- end }}
+      {{- with .Values.localEmbeddings.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.localEmbeddings.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.localEmbeddings.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
 ---
 apiVersion: v1

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -382,12 +382,15 @@ localEmbeddings:
   # Pod scheduling controls for the local embeddings Deployment only (issue #755).
   # All three are empty by default and are omitted entirely from the rendered
   # manifest unless set — nothing is scheduled differently until you opt in.
-  # Use them to pin TEI to architecture-compatible nodes (the image is not always
-  # multi-arch), to place it on a dedicated/accelerator node pool, or to let it
+  # Use them to pin TEI to architecture-compatible nodes (the default TEI image is
+  # amd64 only), to place it on a dedicated/accelerator node pool, or to let it
   # run on tainted nodes.
-  nodeSelector: {}                  # Node labels the pod must match, e.g. {kubernetes.io/arch: arm64}
-  affinity: {}                      # Standard pod affinity/anti-affinity rules (node, pod, podAnti)
-  tolerations: []                   # Taints the pod tolerates, e.g. a dedicated embeddings node pool
+  nodeSelector: {}                  # Node labels the pod must match, e.g. {kubernetes.io/arch: amd64}
+  affinity: {}                      # Standard Kubernetes affinity rules (nodeAffinity, podAffinity, podAntiAffinity)
+  tolerations: []                   # Taints the pod tolerates. Prefer a specific key, e.g.
+                                    # [{key: dedicated, operator: Equal, value: embeddings, effect: NoSchedule}].
+                                    # A keyless `operator: Exists` tolerates EVERY taint, including
+                                    # node-role.kubernetes.io/control-plane — avoid it.
 
 # Dex OIDC Provider (PRD #380)
 # Deploys Dex as the identity provider for OAuth2/OIDC authentication.

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -379,6 +379,15 @@ localEmbeddings:
     limits:
       cpu: "1"
       memory: "512Mi"
+  # Pod scheduling controls for the local embeddings Deployment only (issue #755).
+  # All three are empty by default and are omitted entirely from the rendered
+  # manifest unless set — nothing is scheduled differently until you opt in.
+  # Use them to pin TEI to architecture-compatible nodes (the image is not always
+  # multi-arch), to place it on a dedicated/accelerator node pool, or to let it
+  # run on tainted nodes.
+  nodeSelector: {}                  # Node labels the pod must match, e.g. {kubernetes.io/arch: arm64}
+  affinity: {}                      # Standard pod affinity/anti-affinity rules (node, pod, podAnti)
+  tolerations: []                   # Taints the pod tolerates, e.g. a dedicated embeddings node pool
 
 # Dex OIDC Provider (PRD #380)
 # Deploys Dex as the identity provider for OAuth2/OIDC authentication.

--- a/docs/ai-engine/setup/deployment.md
+++ b/docs/ai-engine/setup/deployment.md
@@ -403,7 +403,7 @@ This is already included in the [Quick Start](#quick-start-5-minutes) above. No 
 | **Model** | `all-MiniLM-L6-v2` (384 dimensions) |
 | **Resource footprint** | ~256 MB RAM, 250m CPU (request) |
 | **GPU** | Not required |
-| **Architecture** | amd64 only (no ARM64/Apple Silicon — see [TEI issue #769](https://github.com/huggingface/text-embeddings-inference/issues/769)) |
+| **Architecture** | amd64 only (no ARM64/Apple Silicon — see [TEI issue #769](https://github.com/huggingface/text-embeddings-inference/issues/769)). On mixed clusters, pin the pod to amd64 nodes — see [Pod scheduling](#local-embeddings-scheduling) |
 
 To customize the model or resources:
 
@@ -434,6 +434,35 @@ localEmbeddings:
 ```
 
 > ⚠️ **When to leave it off (the default):** prefetch requires PyPI **and** HuggingFace to be reachable at pod startup and only supports **public, non-gated** models (no `HF_TOKEN` is passed). Leave it disabled for air-gapped clusters, gated/private models, a `model:` set to a local path, or a custom pre-baked TEI image — in those cases prefetch would break a setup that otherwise works.
+
+#### Pod scheduling (nodeSelector, affinity, tolerations) {#local-embeddings-scheduling}
+
+By default the embeddings pod carries no scheduling constraints, so the scheduler places it on any node with room. That is the wrong node when only some of your nodes can run it — a mixed-architecture cluster (the TEI image is amd64 only, see the table above), a dedicated or accelerator node pool, or nodes reserved behind taints. Three optional values add the standard Kubernetes scheduling fields to the local-embeddings Deployment, and to nothing else in the chart:
+
+```yaml
+localEmbeddings:
+  enabled: true
+  nodeSelector:                     # Node labels the pod must match
+    kubernetes.io/arch: amd64
+  affinity:                         # Standard node/pod affinity and anti-affinity rules
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-pool
+                operator: In
+                values:
+                  - embeddings
+  tolerations:                      # Taints the pod tolerates
+    - key: dedicated
+      operator: Equal
+      value: embeddings
+      effect: NoSchedule
+```
+
+Each value is independent — set only the ones you need. What you provide is passed through verbatim to `spec.template.spec` of the local-embeddings Deployment, so any valid Kubernetes [pod-to-node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) or [taint and toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) syntax works. All three are empty by default and are omitted from the rendered manifest entirely, so an existing install schedules exactly as before until you set one.
+
+> ⚠️ **On mixed-architecture clusters, pin to amd64.** The TEI image is amd64 only ([TEI issue #769](https://github.com/huggingface/text-embeddings-inference/issues/769)), so on a cluster that also has ARM64 nodes the embeddings pod can be placed on a node it cannot run on. Setting `nodeSelector: {kubernetes.io/arch: amd64}` keeps it on nodes where it starts. These values control **where** the pod is scheduled — they do not make TEI run on an unsupported architecture.
 
 To disable local embeddings (e.g., if using a cloud provider instead):
 

--- a/tests/unit/helm/local-embeddings-scheduling.test.ts
+++ b/tests/unit/helm/local-embeddings-scheduling.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit Test: Local embeddings pod scheduling options (Issue #755)
+ *
+ * Tests that nodeSelector, affinity and tolerations render under
+ * spec.template.spec of the local-embeddings Deployment only, and that
+ * their empty defaults are omitted from the rendered manifest entirely.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { execSync } from 'child_process';
+import * as yaml from 'js-yaml';
+
+interface PodSpec {
+  containers: Array<{
+    name: string;
+    image: string;
+    args?: string[];
+  }>;
+  nodeSelector?: Record<string, string>;
+  affinity?: Record<string, unknown>;
+  tolerations?: Array<Record<string, unknown>>;
+  terminationGracePeriodSeconds?: number;
+}
+
+interface DeploymentResource {
+  apiVersion: string;
+  kind: 'Deployment';
+  metadata: { name: string };
+  spec: {
+    template: {
+      spec: PodSpec;
+    };
+  };
+}
+
+function helmTemplate(setValues: string[] = [], setJsonValues: string[] = []): unknown[] {
+  const chartPath = './charts';
+  const setArgs = setValues.map(v => `--set ${v}`).join(' ');
+  const setJsonArgs = setJsonValues.map(v => `--set-json '${v}'`).join(' ');
+  const cmd = `helm template test-release ${chartPath} ${setArgs} ${setJsonArgs} 2>&1`;
+  const output = execSync(cmd, { encoding: 'utf-8' });
+  return yaml.loadAll(output).filter(Boolean);
+}
+
+function findResourcesByKind<T>(docs: unknown[], kind: string, nameIncludes?: string): T[] {
+  return docs.filter(
+    (doc: unknown) =>
+      typeof doc === 'object' &&
+      doc !== null &&
+      (doc as Record<string, unknown>).kind === kind &&
+      (!nameIncludes ||
+        ((doc as Record<string, unknown>).metadata as Record<string, unknown>)?.name
+          ?.toString()
+          .includes(nameIncludes))
+  ) as T[];
+}
+
+function getLocalEmbeddingsPodSpec(docs: unknown[]): PodSpec {
+  const deployments = findResourcesByKind<DeploymentResource>(docs, 'Deployment', 'local-embeddings');
+  expect(deployments).toHaveLength(1);
+  return deployments[0].spec.template.spec;
+}
+
+const AFFINITY_JSON =
+  'localEmbeddings.affinity={"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":' +
+  '{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/arch","operator":"In","values":["arm64"]}]}]}}}';
+
+const TOLERATIONS_JSON =
+  'localEmbeddings.tolerations=[{"key":"dedicated","operator":"Equal","value":"embeddings","effect":"NoSchedule"},' +
+  '{"key":"gpu","operator":"Exists","effect":"NoExecute"}]';
+
+const NODE_SELECTOR_JSON =
+  'localEmbeddings.nodeSelector={"kubernetes.io/arch":"arm64","node-pool":"embeddings"}';
+
+describe.concurrent('Local embeddings pod scheduling options (Issue #755)', () => {
+
+  test('defaults: no nodeSelector, affinity or tolerations keys in the pod spec', () => {
+    const docs = helmTemplate(['localEmbeddings.enabled=true']);
+    const podSpec = getLocalEmbeddingsPodSpec(docs);
+
+    expect(podSpec.nodeSelector).toBeUndefined();
+    expect(podSpec.affinity).toBeUndefined();
+    expect(podSpec.tolerations).toBeUndefined();
+    expect(Object.keys(podSpec)).not.toContain('nodeSelector');
+    expect(Object.keys(podSpec)).not.toContain('affinity');
+    expect(Object.keys(podSpec)).not.toContain('tolerations');
+  });
+
+  test('nodeSelector renders under spec.template.spec with the exact map', () => {
+    const docs = helmTemplate(['localEmbeddings.enabled=true'], [NODE_SELECTOR_JSON]);
+    const podSpec = getLocalEmbeddingsPodSpec(docs);
+
+    expect(podSpec.nodeSelector).toEqual({
+      'kubernetes.io/arch': 'arm64',
+      'node-pool': 'embeddings',
+    });
+    expect(podSpec.affinity).toBeUndefined();
+    expect(podSpec.tolerations).toBeUndefined();
+  });
+
+  test('tolerations render under spec.template.spec as a list with exact entries', () => {
+    const docs = helmTemplate(['localEmbeddings.enabled=true'], [TOLERATIONS_JSON]);
+    const podSpec = getLocalEmbeddingsPodSpec(docs);
+
+    expect(podSpec.tolerations).toEqual([
+      { key: 'dedicated', operator: 'Equal', value: 'embeddings', effect: 'NoSchedule' },
+      { key: 'gpu', operator: 'Exists', effect: 'NoExecute' },
+    ]);
+    expect(podSpec.nodeSelector).toBeUndefined();
+    expect(podSpec.affinity).toBeUndefined();
+  });
+
+  test('affinity renders under spec.template.spec preserving nested structure', () => {
+    const docs = helmTemplate(['localEmbeddings.enabled=true'], [AFFINITY_JSON]);
+    const podSpec = getLocalEmbeddingsPodSpec(docs);
+
+    expect(podSpec.affinity).toEqual({
+      nodeAffinity: {
+        requiredDuringSchedulingIgnoredDuringExecution: {
+          nodeSelectorTerms: [
+            {
+              matchExpressions: [
+                { key: 'kubernetes.io/arch', operator: 'In', values: ['arm64'] },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(podSpec.nodeSelector).toBeUndefined();
+    expect(podSpec.tolerations).toBeUndefined();
+  });
+
+  test('all three set together render correctly and leave the rest of the pod spec unaffected', () => {
+    const docs = helmTemplate(
+      ['localEmbeddings.enabled=true'],
+      [NODE_SELECTOR_JSON, AFFINITY_JSON, TOLERATIONS_JSON]
+    );
+    const podSpec = getLocalEmbeddingsPodSpec(docs);
+
+    expect(podSpec.nodeSelector).toEqual({
+      'kubernetes.io/arch': 'arm64',
+      'node-pool': 'embeddings',
+    });
+    expect(podSpec.affinity?.nodeAffinity).toBeDefined();
+    expect(podSpec.tolerations).toHaveLength(2);
+
+    // Rest of the pod spec is untouched
+    expect(podSpec.terminationGracePeriodSeconds).toBe(30);
+    expect(podSpec.containers).toHaveLength(1);
+    const container = podSpec.containers[0];
+    expect(container.name).toBe('local-embeddings');
+    expect(container.image).toContain('text-embeddings-inference');
+    expect(container.args).toEqual([
+      '--model-id',
+      'sentence-transformers/all-MiniLM-L6-v2',
+      '--port',
+      '80',
+    ]);
+  });
+
+  test('isolation: no other Deployment gains nodeSelector, affinity or tolerations', () => {
+    const docs = helmTemplate(
+      ['localEmbeddings.enabled=true'],
+      [NODE_SELECTOR_JSON, AFFINITY_JSON, TOLERATIONS_JSON]
+    );
+
+    const deployments = findResourcesByKind<DeploymentResource>(docs, 'Deployment');
+    const others = deployments.filter(d => !d.metadata.name.includes('local-embeddings'));
+    // Main MCP server Deployment plus at least the agentic-tools plugin Deployment
+    expect(others.length).toBeGreaterThanOrEqual(2);
+
+    // The main MCP server Deployment must be among them and unaffected
+    const mainDeploy = others.find(
+      d => !d.metadata.name.includes('agentic-tools') && !d.metadata.name.includes('dex')
+    );
+    expect(mainDeploy).toBeDefined();
+
+    for (const deployment of others) {
+      const podSpec = deployment.spec.template.spec;
+      expect(podSpec.nodeSelector, `${deployment.metadata.name} nodeSelector`).toBeUndefined();
+      expect(podSpec.affinity, `${deployment.metadata.name} affinity`).toBeUndefined();
+      expect(podSpec.tolerations, `${deployment.metadata.name} tolerations`).toBeUndefined();
+    }
+  });
+});

--- a/tests/unit/helm/local-embeddings-scheduling.test.ts
+++ b/tests/unit/helm/local-embeddings-scheduling.test.ts
@@ -33,6 +33,18 @@ interface DeploymentResource {
   };
 }
 
+/** Deployment or StatefulSet - both carry a pod template that could gain scheduling keys */
+interface WorkloadResource {
+  apiVersion: string;
+  kind: 'Deployment' | 'StatefulSet';
+  metadata: { name: string };
+  spec: {
+    template: {
+      spec: PodSpec;
+    };
+  };
+}
+
 function helmTemplate(setValues: string[] = [], setJsonValues: string[] = []): unknown[] {
   const chartPath = './charts';
   const setArgs = setValues.map(v => `--set ${v}`).join(' ');
@@ -71,6 +83,18 @@ const TOLERATIONS_JSON =
 
 const NODE_SELECTOR_JSON =
   'localEmbeddings.nodeSelector={"kubernetes.io/arch":"arm64","node-pool":"embeddings"}';
+
+// Enables the subcharts that issue #755 requirement 2 names explicitly. Dex renders only
+// when its preconditions (secret, admin hash, both external URLs) are satisfied; Qdrant
+// renders by default but as a StatefulSet, so neither is covered by a defaults-only render.
+const SUBCHARTS_ENABLED = [
+  'localEmbeddings.enabled=true',
+  'dex.enabled=true',
+  'dex.existingSecret=my-secret',
+  'dex.adminPasswordHash=hash',
+  'dex.externalUrl=https://dex.example.com',
+  'externalUrl=https://dot-ai.example.com',
+];
 
 describe.concurrent('Local embeddings pod scheduling options (Issue #755)', () => {
 
@@ -181,6 +205,86 @@ describe.concurrent('Local embeddings pod scheduling options (Issue #755)', () =
       expect(podSpec.nodeSelector, `${deployment.metadata.name} nodeSelector`).toBeUndefined();
       expect(podSpec.affinity, `${deployment.metadata.name} affinity`).toBeUndefined();
       expect(podSpec.tolerations, `${deployment.metadata.name} tolerations`).toBeUndefined();
+    }
+  });
+
+  test('isolation: Dex and Qdrant workloads are unaffected when the subcharts are enabled', () => {
+    const docs = helmTemplate(SUBCHARTS_ENABLED, [
+      NODE_SELECTOR_JSON,
+      AFFINITY_JSON,
+      TOLERATIONS_JSON,
+    ]);
+
+    // Qdrant is a StatefulSet, so a Deployment-only filter would silently skip it
+    const workloads = [
+      ...findResourcesByKind<WorkloadResource>(docs, 'Deployment'),
+      ...findResourcesByKind<WorkloadResource>(docs, 'StatefulSet'),
+    ];
+    const names = workloads.map(w => w.metadata.name);
+
+    // The two workloads issue #755 names must actually be in the render, not assumed
+    expect(names.some(n => n.includes('dex')), `rendered: ${names.join(', ')}`).toBe(true);
+    expect(names.some(n => n.includes('qdrant')), `rendered: ${names.join(', ')}`).toBe(true);
+    expect(names.some(n => n.includes('agentic-tools'))).toBe(true);
+    expect(
+      names.some(
+        n =>
+          !n.includes('dex') &&
+          !n.includes('qdrant') &&
+          !n.includes('agentic-tools') &&
+          !n.includes('local-embeddings')
+      ),
+      'main dot-ai Deployment'
+    ).toBe(true);
+    expect(workloads.length).toBeGreaterThanOrEqual(5);
+
+    const target = workloads.filter(w => w.metadata.name.includes('local-embeddings'));
+    expect(target).toHaveLength(1);
+    expect(target[0].spec.template.spec.nodeSelector).toEqual({
+      'kubernetes.io/arch': 'arm64',
+      'node-pool': 'embeddings',
+    });
+    expect(target[0].spec.template.spec.affinity?.nodeAffinity).toBeDefined();
+    expect(target[0].spec.template.spec.tolerations).toHaveLength(2);
+
+    for (const workload of workloads) {
+      if (workload.metadata.name.includes('local-embeddings')) continue;
+      const label = `${workload.kind}/${workload.metadata.name}`;
+      const podSpec = workload.spec.template.spec;
+      expect(podSpec.nodeSelector, `${label} nodeSelector`).toBeUndefined();
+      expect(podSpec.affinity, `${label} affinity`).toBeUndefined();
+      expect(podSpec.tolerations, `${label} tolerations`).toBeUndefined();
+    }
+  });
+
+  test('enabled=false: scheduling values set render no local-embeddings resources at all', () => {
+    const docs = helmTemplate(
+      ['localEmbeddings.enabled=false'],
+      [NODE_SELECTOR_JSON, TOLERATIONS_JSON]
+    );
+
+    expect(
+      findResourcesByKind<DeploymentResource>(docs, 'Deployment', 'local-embeddings')
+    ).toHaveLength(0);
+
+    // Nothing local-embeddings-related is emitted - not the Deployment, not the Service
+    const localEmbeddingsDocs = docs.filter(doc =>
+      ((doc as Record<string, unknown>).metadata as Record<string, unknown>)?.name
+        ?.toString()
+        .includes('local-embeddings')
+    );
+    expect(localEmbeddingsDocs).toHaveLength(0);
+
+    // And no other workload picked the values up
+    const workloads = [
+      ...findResourcesByKind<WorkloadResource>(docs, 'Deployment'),
+      ...findResourcesByKind<WorkloadResource>(docs, 'StatefulSet'),
+    ];
+    expect(workloads.length).toBeGreaterThanOrEqual(3);
+    for (const workload of workloads) {
+      const label = `${workload.kind}/${workload.metadata.name}`;
+      expect(workload.spec.template.spec.nodeSelector, `${label} nodeSelector`).toBeUndefined();
+      expect(workload.spec.template.spec.tolerations, `${label} tolerations`).toBeUndefined();
     }
   });
 });


### PR DESCRIPTION
## Summary

Adds standard Kubernetes pod scheduling controls to the local-embeddings Deployment, so platform operators can control which nodes it runs on without an out-of-chart post-render patch.

Three optional Helm values under `localEmbeddings` are rendered verbatim under `spec.template.spec` of the local-embeddings Deployment **only**:

```yaml
localEmbeddings:
  nodeSelector: {}
  affinity: {}
  tolerations: []
```

Use cases:
- Pin the TEI pod to amd64 nodes on a mixed-architecture cluster (the default TEI image is amd64-only)
- Place it on a dedicated/accelerator node pool via `affinity`
- Let it run on tainted nodes via `tolerations`

All three are empty by default and are omitted entirely from the rendered manifest, so existing installs render byte-for-byte unchanged. No architecture or scheduling policy is hardcoded in the chart.

Closes #755

## Changes

- `charts/templates/local-embeddings.yaml` — renders `nodeSelector`/`affinity`/`tolerations` under `spec.template.spec` when set
- `charts/values.yaml` — new values with empty defaults (`{}` / `{}` / `[]`) plus comments
- `docs/ai-engine/setup/deployment.md` — new "Pod scheduling" subsection with examples and an amd64-pinning callout
- `tests/unit/helm/local-embeddings-scheduling.test.ts` — new file, 8 tests covering rendering and isolation from other chart resources
- `changelog.d/755.feature.md` — changelog fragment

Note: this branch also carries a pre-existing, unrelated commit (`bce35c9`, "chore: remove dot-ai skills generate SessionStart hook", `.claude/settings.json`) that predates this feature work.

## Verification

- 8/8 tests pass in the new test file
- Full unit suite: 56 files / 945 passed / 3 skipped
- `npm run lint` clean
- `helm lint ./charts` clean
- Rendered output at defaults is byte-identical to `main` across four different value sets
- Isolation confirmed with Dex enabled — scheduling keys appear only in the local-embeddings Deployment document, not in dot-ai, agentic-tools, Dex, or the Qdrant StatefulSet
- Security audit found nothing exploitable

Full `npm run test:integration` (Kind-cluster e2e suite) has not been run locally and runs as this PR's CI gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Kubernetes scheduling controls for the local embeddings service, including node selection, affinity rules, and tolerations.
  - Scheduling settings can be configured independently and are omitted by default, enabling deployment to dedicated, accelerator, or tainted-node pools.
- **Documentation**
  - Documented local embeddings’ amd64 architecture requirement.
  - Added configuration guidance for the new scheduling options and clarified that they apply only to the local embeddings deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->