### PR TITLE
fix: Fix the invalid image tag in the deployment manifest to use a valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing from the non-existent tag 'v999-nonexistent' to 'latest' allows the image to be successfully pulled from the registry. Argo CD's automated sync policy will automatically reconcile this change to the cluster.

**Risk Level:** low