### PR TITLE
fix(deps): update nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -463,22 +463,6 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/openai-compatible": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.47.tgz",
-      "integrity": "sha512-Enm5UlL0zUCrW3792opk5h7hRWxZOZzDe6eQYVFqX9LUOGGCe1h8MZWAGim765nwzgnjlpeYOsuzZmLtRsTPlg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
@@ -6519,9 +6503,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## What

Bump the `nanoid` lockfile pin from 3.3.17 to 3.3.18.

## Why

The `Security Analysis` job fails on every PR with a high-severity advisory:

```
1139427 │ nanoid │ custom generators can loop indefinitely when size is zero │ high
        GHSA-2v37-7h3g-55p8 — patched in 3.3.18 (3.x line)
```

This is currently red on `main` and on every open PR (#756, #757, #760), unrelated to any of their changes.

`nanoid` is a **dev-only transitive dependency** — `vitest → vite → postcss → nanoid`, and `npm ls nanoid --omit=dev` is empty — so nothing published or containerized is affected. But `better-npm-audit` walks the whole tree, so it blocks the check regardless.

## How

`postcss@8.5.26` already declares `nanoid: ^3.3.17`, which permits the patched 3.3.18 — only the lockfile resolution was stale. So `npm update nanoid --package-lock-only` is the entire fix; **no `overrides` entry needed** and `package.json` is untouched.

The update also drops a leftover nested `@ai-sdk/xai/node_modules/@ai-sdk/openai-compatible@2.0.47` entry. `@ai-sdk/xai@3.0.117` depends on exactly `2.0.66`, which is already the hoisted version, so this aligns the lockfile with what xai actually requires rather than changing behavior.

## Testing

- `npx --no-install better-npm-audit audit --level moderate` → `🤝 All good!` (exit 0); previously exit 1
- `package.json` unchanged; `package-lock.json` is 3 insertions / 19 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)