### PR TITLE
fix: Fix the container image tag in the deployment manifest from 'nginx:v999-nonexistent' to 'nginx:latest'

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The invalid image tag causes the pod to fail during image pull. Updating to a valid and well-tested nginx image tag resolves the ImagePullBackOff error. Argo CD will automatically sync the change due to its automated sync policy.

**Risk Level:** low