### PR TITLE
test(copilot): isolate integration credential checks

### DIFF
--- a/changelog.d/759-copilot-integration-credential-isolation.bugfix.md
+++ b/changelog.d/759-copilot-integration-credential-isolation.bugfix.md
@@ -1,0 +1,4 @@
+**Copilot integration credential isolation**
+
+Copilot integration tests now find supported credentials across the full
+environment chain and reject PAT shapes independently of ambient credentials.

--- a/changelog.d/759-copilot-integration-credential-isolation.bugfix.md
+++ b/changelog.d/759-copilot-integration-credential-isolation.bugfix.md
@@ -1,4 +1,0 @@
-**Copilot integration credential isolation**
-
-Copilot integration tests now find supported credentials across the full
-environment chain and reject PAT shapes independently of ambient credentials.

--- a/changelog.d/759.misc.md
+++ b/changelog.d/759.misc.md
@@ -1,0 +1,4 @@
+**Copilot integration credential detection**
+
+Copilot integration tests now search the full environment chain for a
+supported credential instead of checking only the first populated variable.

--- a/tests/integration/tools/copilot-provider.test.ts
+++ b/tests/integration/tools/copilot-provider.test.ts
@@ -14,20 +14,14 @@
 
 import { describe, test, expect, beforeAll } from 'vitest';
 import { IntegrationTest } from '../helpers/test-base.js';
-import {
-  isSupportedCopilotToken,
-  makeCopilotCredentialResolver,
-} from '../../../src/core/providers/copilot-token-exchanger.js';
-
-const COPILOT_TOKEN =
-  process.env.GITHUB_COPILOT_TOKEN ||
-  process.env.GH_TOKEN ||
-  process.env.GITHUB_TOKEN;
+import { isSupportedCopilotToken } from '../../../src/core/providers/copilot-token-exchanger.js';
 
 const isCopilotProvider = process.env.AI_PROVIDER === 'copilot';
-const hasUsableToken = Boolean(
-  COPILOT_TOKEN && isSupportedCopilotToken(COPILOT_TOKEN)
-);
+const hasUsableToken = [
+  process.env.GITHUB_COPILOT_TOKEN,
+  process.env.GH_TOKEN,
+  process.env.GITHUB_TOKEN,
+].some(token => token && isSupportedCopilotToken(token));
 const shouldRun = isCopilotProvider && hasUsableToken;
 
 // Emit a clear skip reason so CI logs are searchable
@@ -50,14 +44,11 @@ describe.concurrent('GitHub Copilot Provider Integration', () => {
     if (!shouldRun) return;
   });
 
-  test('should reject fine-grained PATs before calling the Copilot API', () => {
-    const resolver = makeCopilotCredentialResolver(
-      'github_pat_unsupportedForCopilotInference'
-    );
-
-    expect(() => resolver.resolve()).toThrow(
-      /Personal access tokens \(github_pat_\* and ghp_\*\) are not supported/
-    );
+  test.each([
+    'github_pat_unsupportedForCopilotInference',
+    'ghp_unsupportedForCopilotInference',
+  ])('should reject unsupported PAT shape %s', token => {
+    expect(isSupportedCopilotToken(token)).toBe(false);
   });
 
   test.skipIf(!shouldRun)(

--- a/tests/integration/tools/copilot-provider.test.ts
+++ b/tests/integration/tools/copilot-provider.test.ts
@@ -12,7 +12,7 @@
  * PRD #587: GitHub Copilot Provider
  */
 
-import { describe, test, expect, beforeAll } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { IntegrationTest } from '../helpers/test-base.js';
 import { isSupportedCopilotToken } from '../../../src/core/providers/copilot-token-exchanger.js';
 
@@ -39,10 +39,6 @@ if (!shouldRun) {
 
 describe.concurrent('GitHub Copilot Provider Integration', () => {
   const integrationTest = new IntegrationTest();
-
-  beforeAll(async () => {
-    if (!shouldRun) return;
-  });
 
   test.skipIf(!shouldRun)(
     'should return a valid version response when using Copilot provider',

--- a/tests/integration/tools/copilot-provider.test.ts
+++ b/tests/integration/tools/copilot-provider.test.ts
@@ -44,13 +44,6 @@ describe.concurrent('GitHub Copilot Provider Integration', () => {
     if (!shouldRun) return;
   });
 
-  test.each([
-    'github_pat_unsupportedForCopilotInference',
-    'ghp_unsupportedForCopilotInference',
-  ])('should reject unsupported PAT shape %s', token => {
-    expect(isSupportedCopilotToken(token)).toBe(false);
-  });
-
   test.skipIf(!shouldRun)(
     'should return a valid version response when using Copilot provider',
     async () => {


### PR DESCRIPTION
## What

- Scan all three Copilot credential environment variables for the first supported token shape, instead of shape-checking only the first populated variable.
- Delete the `should reject fine-grained PATs before calling the Copilot API` test rather than rewriting it — both halves are already covered by the unit suite, which unlike this file runs in CI.
- Remove the resulting no-op `beforeAll` hook and its now-unused import.
- Add the towncrier fragment as `changelog.d/759.misc.md`.

## Why

This addresses follow-up items A and B from the maintainer verification on #759.

**Item A** — a stale unsupported token in an earlier environment slot could hide a supported token later in the chain, so the skip gate disagreed with the production resolver. The gate now mirrors `makeCopilotCredentialResolver` (`src/core/providers/copilot-token-exchanger.ts:50-65`), which skips unsupported entries and keeps walking the chain.

**Item B** — the PAT rejection test could fail whenever the developer had a valid Copilot credential in the ambient environment. `makeCopilotCredentialResolver(pat).resolve()` throws only when the *entire* env chain is unusable, so the PAT argument alone never determined the outcome; the assertion was reading the ambient environment rather than the PAT. Per review, it is deleted rather than relocated:

- `tests/unit/core/providers/vercel-provider.copilot.test.ts:68-75` already asserts `isSupportedCopilotToken` is `false` for both `ghp_*` and `github_pat_*`.
- `tests/unit/core/providers/copilot-token-exchanger.test.ts:63-70` already asserts the exact regex removed here, with `afterEach` env isolation.

`tests/integration/CLAUDE.md` rules out tests that duplicate coverage held elsewhere, so removing it costs nothing and leaves a straightforward opt-in suite.

This PR intentionally does not address the separate part-2 credential-scope design decision, nor the integration-harness wiring (`run-integration-tests.sh` creates `dot-ai-secrets` without a `copilot-token` key) — both are maintainer follow-ups tracked outside this PR.

Refs #759

## Testing

- Mixed chain (`GITHUB_COPILOT_TOKEN=ghp_stalePATfake`, `GH_TOKEN=gho_goodOAuthFake`): reproduced the false skip on `main`, confirmed the gate opens on this branch.
- PAT-only chain and unset `AI_PROVIDER`: gate still closes with the expected skip reason.
- Copilot unit suites: 18 passed, 1 live e2e skipped.
- `tsc --noEmit`, Prettier check, and ESLint run directly against the changed test file: all clean. (Note that `npm run lint` and `npm run build:dev` do not cover `tests/` — separate follow-up.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Copilot integration test credential detection to check all supported environment variables and use the first valid token found, reducing false failures when credentials are configured across multiple locations.

* **Documentation**
  * Added a changelog entry describing the updated credential detection behavior and supported credential lookup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
