### PR TITLE
fix: Fix the container image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image from non-existent 'nginx:v999-nonexistent' to a valid and available 'nginx:latest' tag will allow the kubelet to successfully pull the image and start the pod. Argo CD's automated sync will apply the fix automatically.

**Risk Level:** low