### PR TITLE
fix: Fix the invalid image tag in the deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

The image tag 'nginx:v999-nonexistent' does not exist in any Docker registry. Changing it to 'nginx:latest' provides a valid, existing image. Argo CD will automatically sync the change due to the application's automated sync policy and self-heal configuration.

**Risk Level:** low