### PR TITLE
fix: Fix image tag in deployment manifest from invalid tag to valid nginx version

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' (or another valid nginx tag) allows the kubelet to successfully pull the image. Argo CD will automatically sync the corrected manifest from Git due to its automated sync policy (AutoSync enabled with selfHeal=true), and the pod will start running.

**Risk Level:** low