### PR TITLE
fix: Fix invalid Docker image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from non-existent 'nginx:v999-nonexistent' to valid 'nginx:latest' allows kubelet to successfully pull the image. Argo CD will automatically sync this change and pods will start running.

**Risk Level:** low