### PR TITLE
fix: Fix invalid image tag in deployment manifest

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing the image tag to 'nginx:latest' provides a valid, publicly available nginx image that kubelet can successfully pull. Argo CD will automatically sync the change and redeploy the pod.

**Risk Level:** low