### PR TITLE
fix: Fix image tag in deployment manifest to use valid nginx image

### DIFF
--- a/tests/integration/fixtures/gitops/broken-app/deployment.yaml
+++ b/tests/integration/fixtures/gitops/broken-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:v999-nonexistent
+        image: nginx:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Remediation

Changing image tag from 'v999-nonexistent' to 'latest' resolves the ImagePullBackOff error. The 'latest' tag is a well-known valid tag that exists in the Docker registry. Argo CD will automatically detect the change and resync the deployment.

**Risk Level:** low